### PR TITLE
Remove logging handler

### DIFF
--- a/src/ansys/grantami/common/__init__.py
+++ b/src/ansys/grantami/common/__init__.py
@@ -5,10 +5,6 @@ from ._util import SessionConfiguration
 from ._exceptions import ApiConnectionException, ApiException
 from ._api_client import ApiClient
 
-logging.basicConfig(
-    format="%(asctime)s\t%(levelname)s\t%(message)s", level=logging.DEBUG
-)
-
 __all__ = [
     "ApiClient",
     "ApiClientFactory",


### PR DESCRIPTION
Closes #14 

I think this is all that needs to be done... I have confirmed that with this change no logs are generated in a script that uses the BoM Analysis package, unless logging output is requested in that script. In that case, all BoM Analysis and generic transport logs are emitted.