### PR TITLE
Fix issue with no OIDC extra and logger naming

### DIFF
--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -28,7 +28,7 @@ if os.getenv("VERBOSE_TOKEN_DEBUGGING"):
 else:
     _log_tokens = False
 
-logger = logging.getLogger("MI_Session")
+logger = logging.getLogger("ansys.openapi.common")
 
 
 class OIDCSessionFactory:

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -10,7 +10,6 @@ from requests.auth import HTTPBasicAuth  # type: ignore
 from requests_ntlm import HttpNtlmAuth  # type: ignore
 
 from ._api_client import ApiClient
-from ._oidc import OIDCSessionFactory
 from ._util import (
     parse_authenticate,
     SessionConfiguration,
@@ -18,7 +17,7 @@ from ._util import (
 )
 from ._exceptions import ApiConnectionException, AuthenticationWarning
 
-logger = logging.getLogger("pyansys.grantami.common")
+logger = logging.getLogger("ansys.openapi.common")
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -31,6 +30,7 @@ try:
     # noinspection PyUnresolvedReferences
     import requests_oauthlib  # type: ignore
     import keyring
+    from ._oidc import OIDCSessionFactory
 except ImportError:
     _oidc_enabled = False
 


### PR DESCRIPTION
Currently importing the module fails without the [oidc] extra because we try to import the OIDCSessionFactory before we check if we have OIDC enabled. This PR moves the import statement into the guard block where it belongs.

We also harmonize the logger names and make them match the package name, we may want to revisit this at a later date.