### PR TITLE
Add handling for absent content-type header

### DIFF
--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -364,7 +364,9 @@ class ApiClient:
         try:
             data = response.json()
         except ValueError:
-            content_type = response.headers.get("Content-Type", "application/octet-stream")
+            content_type = response.headers.get(
+                "Content-Type", "application/octet-stream"
+            )
             if content_type not in ["application/octet-stream"]:
                 data = response.text
             else:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -375,9 +375,7 @@ class TestResponseParsing:
             <heading>Reminder</heading>
             <body>Don't forget me this weekend!</body>
         </note>"""
-        response = self.create_response(
-            text=data, content_type="application/xml"
-        )
+        response = self.create_response(text=data, content_type="application/xml")
         deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
         deserialize_mock.return_value = True
         _ = self._client.deserialize(response, "str")


### PR DESCRIPTION
Closes #13 

Add default content-type header handling, assume it's binary if absent.
- Add default to content-type getter
- Add tests for no header and other non-json value