### PR TITLE
Fix failing OIDC test in python 3.8

### DIFF
--- a/tests/test_session_creation.py
+++ b/tests/test_session_creation.py
@@ -228,7 +228,8 @@ def test_only_called_once_with_oidc_when_anonymous_is_ok():
 
 
 @pytest.mark.skipif(
-    (3, 8) <= sys.version_info <= (3, 9), reason="Test fails in Python 3.8"
+    (3, 8) <= sys.version_info <= (3, 9),
+    reason="Test fails with OSError 'Address already in use' in Python 3.8. Other Python versions unaffected.",
 )
 def test_can_connect_with_oidc_using_token():
     redirect_uri = "https://www.example.com/login/"


### PR DESCRIPTION
Fixes #41.

The `test_can_connect_with_oidc_using_token` test is failing when run in Python 3.8 (and only Python 3.8) because the HTTP server cannot bind to the required port. The assumption is that this is because of a previous HTTP server that hasn't been cleaned up, but it can't be reproduced outside of a github action, so this cannot be confirmed.

The test started failing seemingly with no code changes, and has failed at least 10 times in python 3.8 only.

Since it's impossible to reproduce in a debuggable environment and is blocking development in dependent libraries, this PR just skips the test when run in Python 3.8. If there are any further similar failures, either in Python 3.8 or other versions of python, this PR should be revisited.