### PR TITLE
Pin tox-gh-actions to working version

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox tox-gh-actions==2.8.1
 
     - name: Test with tox
       run: tox


### PR DESCRIPTION
Closes #51

This PR pins the version of tox-gh-actions to 2.8.1 to workaround the bug reported in https://github.com/ymyzk/tox-gh-actions/issues/113