### PR TITLE
CI - Remove tests on Python 3.6

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -66,7 +66,7 @@ jobs:
         - /tmp/keytabs:/tmp/keytabs
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,11 @@ build-backend = "setuptools.build_meta"
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310
 isolated_build = True
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
     Operating System :: POSIX
     Operating System :: MacOS
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
Closes #61 

Python 3.6 is officially EOL, this PR removes test runs and mentions of support for python 3.6