### PR TITLE
67 - Add NullHandler to package logger

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,7 +24,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "sphinx.ext.extlinks",
-    "sphinx.ext.coverage"
+    "sphinx.ext.coverage",
 ]
 
 add_module_names = False
@@ -156,7 +156,7 @@ texinfo_documents = [
         "Engineering Software",
     ),
 ]
-latex_engine = 'xelatex'
+latex_engine = "xelatex"
 
 # -- Options for Epub output -------------------------------------------------
 

--- a/src/ansys/openapi/common/_logger.py
+++ b/src/ansys/openapi/common/_logger.py
@@ -1,0 +1,4 @@
+import logging
+
+logger = logging.getLogger("ansys.openapi.common")
+logger.addHandler(logging.NullHandler())

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import os
 import threading
 import webbrowser
@@ -17,6 +16,7 @@ from ._util import (
     set_session_kwargs,
     RequestsConfiguration,
 )
+from ._logger import logger
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -26,8 +26,6 @@ if os.getenv("VERBOSE_TOKEN_DEBUGGING"):
     _log_tokens = True
 else:
     _log_tokens = False
-
-logger = logging.getLogger("ansys.openapi.common")
 
 
 class OIDCSessionFactory:

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import warnings
 from typing import Tuple, Union, Container, Optional, Mapping, TypeVar, Any
@@ -16,8 +15,7 @@ from ._util import (
     set_session_kwargs,
 )
 from ._exceptions import ApiConnectionException, AuthenticationWarning
-
-logger = logging.getLogger("ansys.openapi.common")
+from ._logger import logger
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:

--- a/src/ansys/openapi/common/_util.py
+++ b/src/ansys/openapi/common/_util.py
@@ -1,5 +1,4 @@
 import http.cookiejar
-import logging
 
 import pyparsing as pp  # type: ignore
 from collections import OrderedDict
@@ -7,6 +6,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from itertools import chain
 from typing import Dict, Union, List, Optional, Tuple, Any, Collection, cast
 from ._exceptions import ApiException
+from ._logger import logger
 
 try:
     from typing import TypedDict
@@ -418,8 +418,6 @@ def handle_response(response: requests.Response) -> requests.Response:
     response : requests.Response
         Response from the API server.
     """
-    logger = logging.getLogger(__name__)
-
     logger.debug(f"response body: {response.text}")
     if not 200 <= response.status_code <= 299:
         raise ApiException.from_response(response)


### PR DESCRIPTION
Closes #67 

Initializing a logger without a handler can cause warnings, this PR moves the logger into a module and imports it from there. We then configure a NullHandler to avoid the warning being emitted.