### PR TITLE
100 - Enable tests for exception reprs

### DIFF
--- a/src/ansys/openapi/common/_exceptions.py
+++ b/src/ansys/openapi/common/_exceptions.py
@@ -104,4 +104,6 @@ class ApiException(Exception):
         return error_message
 
     def __repr__(self) -> str:
-        return f"ApiException({self.status_code}, '{self.reason_phrase}', '{self.body}')"
+        return (
+            f"ApiException({self.status_code}, '{self.reason_phrase}', '{self.body}')"
+        )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -27,7 +27,7 @@ def test_api_connection_exception_repr():
 def test_api_exception_repr():
     status_code = 404
     reason_phrase = "Not Found"
-    message = f"Record with ID \"{str(uuid.uuid4())}\" not found"
+    message = f'Record with ID "{str(uuid.uuid4())}" not found'
 
     api_exception = ApiException(status_code, reason_phrase, message)
     exception_repr = api_exception.__repr__()


### PR DESCRIPTION
Enable skipped tests and fix them so they pass. Exception reprs now function as real __reprs__ and can be used to create clones of the underlying object.