### PR TITLE
64 - Correct docstring for ApiClient.request

### DIFF
--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -520,7 +520,7 @@ class ApiClient(ApiClientBase):
         headers : Dict
             Headers to attach to the request.
         post_params : List[Tuple]
-            Request post form parameters for ``application/x-www-form-urlencoded`` and ``multipart/form-data``.
+            Request post form parameters for ``multipart/form-data``.
         body : SerializedType
             Request body.
         _preload_content : bool, optional


### PR DESCRIPTION
Closes #64

Per ticket the `post_params` parameter of the `ApiClient.request()` method would only ever be used to send `multipart/form-data` requests. This PR makes that clear.