### PR TITLE
[CI] Get coverage to report with SonarCloud

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Test with tox
       run: tox -- --with-kerberos
       
-    - name: Append python version to coverage data
+    - name: Remove platform-specific paths and append platform to coverage file name
       run: |
         sed -i 's/\.tox\/py[0-9]\+\/lib\/python3\.[0-9]\+\/site-packages/src/g' coverage.xml
         sed -i 's/\.tox\.py3[0-9]\+\.lib\.python3\.[0-9]\+\.site-packages\.//g' coverage.xml
@@ -114,12 +114,11 @@ jobs:
     - name: List coverage reports
       run: |
         cp coverage-reports/**/coverage*.xml ./
-        ls
         
     - name: SonarCloud Scan
       uses: SonarSource/sonarcloud-github-action@master
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       with:
         args: >


### PR DESCRIPTION
With some sed magic the coverage reports are now actually parsed and uploaded. There is a warning about the `<sources>` element, since the path is incorrect, but this does not seem to cause problems. I did look at removing the element entirely, since it's optional according to [the DTD](https://github.com/cobertura/web/blob/master/htdocs/xml/coverage-04.dtd) however editing XML with sed is dangerous.

It might be worth farming this out to a bash script and maybe some XSLT, we could also look at getting a switch added to coverage.py to disable the sources element entirely.