### PR TITLE
CI - Use Ansys package repo

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -51,7 +51,7 @@ jobs:
       # Label used to access the service container
       kdc-server:
         # Github container registry address
-        image: ghcr.io/pyansys/kdc-container:v0.2
+        image: ghcr.io/ansys/kdc-container:v0.2
         credentials:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,7 +38,7 @@ autodoc_typehints_description_target = "documented"
 
 # sphinx.ext.intersphinx
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/dev", None),
+    "python": ("https://docs.python.org/3.11", None),
     "requests": ("https://requests.readthedocs.io/en/latest", None),
 }
 


### PR DESCRIPTION
With the move to the Ansys org, github packages have changed namespace. This PR updates the CI step that requires the package.