### PR TITLE
Add PR labelling and release notes configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+documentation:
+- changed-files:
+  - any-glob-to-any-file: ['doc/source/**/*']
+maintenance:
+- changed-files:
+  - any-glob-to-any-file: ['.github/**/*', 'pyproject.toml']
+dependencies:
+- changed-files:
+  - any-glob-to-any-file: ['poetry.lock']

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+  categories:
+    - title: "Features"
+      labels:
+        - enhancement
+    - title: "Documentation"
+      labels:
+        - documentation
+    - title: "Maintenance"
+      labels:
+        - maintenance
+    - title: "Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,0 +1,72 @@
+name: Labeler
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  labeler:
+    name: Set labels
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+
+    # Label based on modified files
+    - name: Label based on changed files
+      uses: actions/labeler@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    # Label based on branch name
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'doc') ||
+        startsWith(github.event.pull_request.head.ref, 'docs')
+      with:
+        labels: documentation
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'maint') ||
+        startsWith(github.event.pull_request.head.ref, 'no-ci') ||
+        startsWith(github.event.pull_request.head.ref, 'ci')
+      with:
+        labels: maintenance
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: startsWith(github.event.pull_request.head.ref, 'feat')
+      with:
+        labels: |
+          enhancement
+
+    - uses: actions-ecosystem/action-add-labels@v1
+      if: |
+        startsWith(github.event.pull_request.head.ref, 'fix') ||
+        startsWith(github.event.pull_request.head.ref, 'patch')
+      with:
+        labels: bug
+
+  commenter:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Suggest to add labels
+      uses: peter-evans/create-or-update-comment@v3
+      # Execute only when no labels have been applied to the pull request
+      if: toJSON(github.event.pull_request.labels.*.name) == '{}'
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          Please add one of the following labels to add this contribution to the Release Notes :point_down:
+          - [bug](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Abug+)
+          - [documentation](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Adocumentation+)
+          - [enhancement](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Aenhancement+)
+          - [good first issue](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Agood+first+issue)
+          - [maintenance](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Amaintenance+)
+          - [release](https://github.com/ansys/grantami-recordlists/pulls?q=label%3Arelease+)


### PR DESCRIPTION
Add a workflow to label PR based on branch name and files modified
Add a configuration file to split auto-generated release notes into sections (and ignore dependency updates that only affect the lock file)