### PR TITLE
Use more PyAnsys actions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -176,7 +176,7 @@ jobs:
 
   release:
     name: "Release"
-#    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build-library]
     runs-on: ubuntu-latest
     steps:
@@ -186,13 +186,11 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           twine-username: "__token__"
           twine-token: ${{ secrets.PYPI_TOKEN }}
-          dry-run: "true"
 
       - uses: ansys/actions/release-github@v5
         name: "Release to GitHub"
         with:
           library-name: ${{ env.LIBRARY_NAME }}
-          dry-run: "true"
 
   doc-deploy-stable:
     name: "Deploy stable documentation"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -175,7 +175,8 @@ jobs:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
   release:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    name: "Release"
+#    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build-library]
     runs-on: ubuntu-latest
     steps:
@@ -185,11 +186,13 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           twine-username: "__token__"
           twine-token: ${{ secrets.PYPI_TOKEN }}
+          dry-run: "true"
 
       - uses: ansys/actions/release-github@v5
         name: "Release to GitHub"
         with:
           library-name: ${{ env.LIBRARY_NAME }}
+          dry-run: "true"
 
   doc-deploy-stable:
     name: "Deploy stable documentation"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+env:
+  MAIN_PYTHON_VERSION: '3.10'
+  LIBRARY_NAME: 'ansys-openapi-common'
+
 jobs:
   code-style:
     name: "Code style"
@@ -18,10 +22,10 @@ jobs:
     steps:
      - uses: ansys/actions/code-style@v5
        with:
-         python-version: "3.10"
+         python-version: ${{ env.MAIN_PYTHON_VERSION }}
          skip-install: "false"
 
-  docs-style:
+  doc-style:
     name: Documentation Style Check
     runs-on: ubuntu-latest
     steps:
@@ -30,9 +34,81 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  test:
+  doc-build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+    needs: doc-style
+
+    steps:
+      - name: "Checkout the repository"
+        uses: actions/checkout@v4
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: "Install system dependencies"
+        run: |
+          sudo apt-get update && sudo apt-get install pandoc libkrb5-dev
+
+      - name: "Install Python dependencies"
+        run: |
+          python -m pip install --upgrade pip tox
+          python -m pip install poetry~=1.7.0
+
+      - name: Install library
+        run: |
+          poetry install --with docs --extras "oidc linux-kerberos"
+
+      - name: Build HTML
+        run: make -C doc html SPHINXOPTS="-W"
+
+      - name: Build PDF Documentation
+        run: |
+          sudo apt update
+          sudo apt-get install -y texlive-latex-extra latexmk texlive-xetex fonts-freefont-otf xindy
+          make -C doc latexpdf
+
+      - name: Upload HTML Documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-html
+          path: doc/build/html
+          retention-days: 7
+
+      - name: Upload PDF Documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-pdf
+          path: doc/build/latex/*.pdf
+          retention-days: 7
+
+  smoke-tests:
+    name: "Build wheelhouse for latest Python versions"
+    runs-on: ${{ matrix.os }}
+    needs: code-style
+    strategy:
+       matrix:
+           os: [ubuntu-latest, windows-latest]
+           python-version: ['3.9', '3.10', '3.11', '3.12']
+    steps:
+      - name: Install kerberos headers
+        if: matrix.os == "ubuntu-latest"
+        run: |
+          sudo apt-get update
+          sudo apt install libkrb5-dev
+
+      - uses: ansys/actions/build-wheelhouse@v5
+        with:
+          library-name: ${{ env.LIBRARY_NAME }}
+          operating-system: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}
+
+  tests:
     name: Unit test on supported platforms
     runs-on: ubuntu-latest
+    needs: smoke-tests
     services:
       # Label used to access the service container
       kdc-server:
@@ -83,97 +159,44 @@ jobs:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
 
-  build:
-    name: Build
+  build-library:
+    name: "Build library"
     runs-on: ubuntu-latest
-
+    needs: [ doc-build, tests ]
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
       - name: Install kerberos headers
         run: |
           sudo apt-get update
           sudo apt install libkrb5-dev
 
-      - name: Create wheel
-        run: |
-          pip install poetry
-          poetry build
-
-      - name: Validate wheel
-        run: |
-          pip install twine
-          twine check dist/*
-
-      - name: Upload wheel
-        uses: actions/upload-artifact@v4
+      - uses: ansys/actions/build-library@v5
         with:
-          name: ansys-grantami-common-wheel
-          path: dist/
-          retention-days: 7
+          library-name: ${{ env.LIBRARY_NAME }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
-  docs:
-    name: Build Documentation
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Install kerberos headers
-        run: |
-          sudo apt-get update
-          sudo apt install libkrb5-dev
-
-      - name: Install library
-        run: |
-          pip install poetry
-          poetry config installer.modern-installation false
-          poetry install --with docs --extras "oidc linux-kerberos"
-
-      - name: Build HTML
-        run: make -C doc html SPHINXOPTS="-W"
-
-      - name: Build PDF Documentation
-        run: |
-          sudo apt update
-          sudo apt-get install -y texlive-latex-extra latexmk texlive-xetex fonts-freefont-otf xindy
-          make -C doc latexpdf
-
-      - name: Upload HTML Documentation
-        uses: actions/upload-artifact@v4
-        with:
-          name: Documentation-html
-          path: doc/build/html
-          retention-days: 7
-
-      - name: Upload PDF Documentation
-        uses: actions/upload-artifact@v4
-        with:
-          name: Documentation-pdf
-          path: doc/build/latex/*.pdf
-          retention-days: 7
-
-  Release:
-    if: contains(github.ref, 'refs/tags')
-    needs: [build, test, code-style, docs]
+  release:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    needs: [build-library]
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: ansys/actions/release-pypi-public@v5
+        name: "Release to public PyPI"
         with:
-          python-version: '3.10'
+          library-name: ${{ env.LIBRARY_NAME }}
+          twine-username: "__token__"
+          twine-token: ${{ secrets.PYPI_TOKEN }}
 
-      - uses: actions/checkout@v4
+      - uses: ansys/actions/release-github@v5
+        name: "Release to GitHub"
+        with:
+          library-name: ${{ env.LIBRARY_NAME }}
 
-      # used for documentation deployment
+  doc-deploy-stable:
+    name: "Deploy stable documentation"
+    runs-on: ubuntu-latest
+    needs: release
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    steps:
       - name: Get Bot Application Token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v3
@@ -183,17 +206,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: ansys-grantami-common-wheel
-          path: ~/dist
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: Documentation-pdf
-          path: ~/pdf
-
-      - uses: actions/download-artifact@v4
-        with:
-          name: Documentation-html
+          name: documentation-html
           path: ~/html
 
       - name: Deploy
@@ -204,21 +217,3 @@ jobs:
           BRANCH: gh-pages
           FOLDER: ~/html
           CLEAN: true
-
-      # note how we use the PyPI tokens
-      - name: Upload to PyPi
-        run: |
-          pip install twine
-          twine upload --non-interactive --skip-existing ~/**/*.whl
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          generate_release_notes: true
-          files: |
-            ./**/*.whl
-            ./**/*.zip
-            ./**/*.pdf

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -94,7 +94,7 @@ jobs:
            python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - name: Install kerberos headers
-        if: matrix.os == "ubuntu-latest"
+        if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
           sudo apt install libkrb5-dev


### PR DESCRIPTION
Closes #458

Uses Ansys actions to build, smoke test (i.e. build wheelhouses) and publish to PyPI and GitHub. This should resolve the GitHub release file attachment issue, although it's difficult to tell without actually releasing. Using 'dry-run' mode on the action looks good though.

The doc publishing is still manual, since we'll need to migrate openapi-common to versioned docs to do that. That's a much larger job.