### PR TITLE
Add checkout step to doc deploy job

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -198,6 +198,8 @@ jobs:
     needs: release
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     steps:
+      - uses: actions/checkout@v4
+
       - name: Get Bot Application Token
         id: get_workflow_token
         uses: peter-murray/workflow-application-token-action@v3


### PR DESCRIPTION
Fix release doc publish failure by adding checkout step to workflow.

I don't think we actually need to checkout this repo, but this is a convenient way of making sure git is setup and authenticated correctly.

Once this is merged I will cherrypick to the release/1.5 branch and try another rc