### PR TITLE
548 - CI - Add doc-changelog action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -174,10 +174,22 @@ jobs:
           library-name: ${{ env.LIBRARY_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
+  update-changelog:
+    name: "Update CHANGELOG for new tag"
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: ansys/actions/doc-deploy-changelog@v6
+        with:
+          token: ${{ '{{ secrets.PYANSYS_CI_BOT_TOKEN }}' }}
+
   release:
     name: "Release"
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [build-library]
+    needs: [build-library, update-changelog]
     runs-on: ubuntu-latest
     steps:
       - uses: ansys/actions/release-pypi-public@v6

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -1,6 +1,7 @@
 name: Labeler
 on:
   pull_request:
+    types: [opened, reopened, synchronize, edited, labeled]
   push:
     branches: [ main ]
 
@@ -38,3 +39,15 @@ jobs:
           - [documentation](https://github.com/ansys/openapi-common/pulls?q=label%3Adocumentation+)
           - [enhancement](https://github.com/ansys/openapi-common/pulls?q=label%3Aenhancement+)
           - [maintenance](https://github.com/ansys/openapi-common/pulls?q=label%3Amaintenance+)
+
+  changelog-fragment:
+      name: "Create changelog fragment"
+      needs: [labeler]
+      permissions:
+        contents: write
+        pull-requests: write
+      runs-on: ubuntu-latest
+      steps:
+      - uses: ansys/actions/doc-changelog@v6
+        with:
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+This project uses [towncrier](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/ansys/{repo-name}/tree/main/doc/changelog.d/>.
+
+<!-- towncrier release notes start -->
+
 ## openapi-common 1.5.1, 2024-03-01
 
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-This project uses [towncrier](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be
-found in <https://github.com/ansys/openapi-common/tree/main/doc/changelog.d/>.
+This project uses [towncrier](https://towncrier.readthedocs.io/) and the
+changes for the upcoming release can be found in
+<https://github.com/ansys/openapi-common/tree/main/doc/changelog.d/>.
 
 <!-- towncrier release notes start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-This project uses [towncrier](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be found in <https://github.com/ansys/{repo-name}/tree/main/doc/changelog.d/>.
+This project uses [towncrier](https://towncrier.readthedocs.io/) and the changes for the upcoming release can be
+found in <https://github.com/ansys/openapi-common/tree/main/doc/changelog.d/>.
 
 <!-- towncrier release notes start -->
 

--- a/doc/changelog.d/563.changed.md
+++ b/doc/changelog.d/563.changed.md
@@ -1,0 +1,1 @@
+548 - CI - Add doc-changelog action

--- a/doc/changelog.d/changelog_template.jinja
+++ b/doc/changelog.d/changelog_template.jinja
@@ -1,0 +1,15 @@
+{% if sections[""] %}
+{% for category, val in definitions.items() if category in sections[""] %}
+
+### {{ definitions[category]['name'] }}
+
+{% for text, values in sections[""][category].items() %}
+- {{ text }} {{ values|join(', ') }}
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,3 +154,38 @@ files = "src"
 explicit_package_bases = true
 mypy_path = "$MYPY_CONFIG_FILE_DIR/src"
 namespace_packages = true
+
+[tool.towncrier]
+package = "ansys.openapi.common"
+directory = "doc/changelog.d"
+filename = "CHANGELOG.md"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+template = "doc/changelog.d/changelog_template.jinja"
+title_format = "## [{version}](https://github.com/ansys/openapi-common/releases/tag/v{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/ansys/openapi-common/pull/{issue})"
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "dependencies"
+name = "Dependencies"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "miscellaneous"
+name = "Miscellaneous"
+showcontent = true


### PR DESCRIPTION
Add the doc-changelog action to update the markdown file as per instructions at:

https://actions.docs.ansys.com/version/stable/migrations/docs-changelog-setup.html#docs-changelog-action-setup