### PR TITLE
CI - 574 - Update codecov action to v4

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -153,7 +153,7 @@ jobs:
       run: tox -- --with-kerberos
 
     - name: Upload coverage report
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       if: ${{ github.actor != 'dependabot[bot]' }}
       with:
         fail_ci_if_error: true


### PR DESCRIPTION
Update the action to get rid of the node version warning