### PR TITLE
Update CNAME to support publishing documentation from this repository

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -14,7 +14,7 @@ on:
 env:
   MAIN_PYTHON_VERSION: '3.10'
   LIBRARY_NAME: 'ansys-openapi-common'
-  DOCUMENTATION_CNAME: 'ansys.github.io/openapi-common/'
+  DOCUMENTATION_CNAME: 'openapi.docs.pyansys.com'
 
 jobs:
   code-style:

--- a/doc/changelog.d/577.changed.md
+++ b/doc/changelog.d/577.changed.md
@@ -1,0 +1,1 @@
+Update CNAME

--- a/doc/changelog.d/577.changed.md
+++ b/doc/changelog.d/577.changed.md
@@ -1,1 +1,1 @@
-Update CNAME
+Update CNAME to support publishing documentation from this repository

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -114,7 +114,7 @@ copybutton_prompt_is_regexp = True
 
 
 # -- Options for HTML output -------------------------------------------------
-cname = os.getenv("DOCUMENTATION_CNAME", "ansys.github.io/openapi-common/")
+cname = os.getenv("DOCUMENTATION_CNAME", "openapi.docs.pyansys.com")
 
 html_theme = "ansys_sphinx_theme"
 html_logo = pyansys_logo_black


### PR DESCRIPTION
Change CNAME to `openapi.docs.pyansys.com`

- [x] Remove it in settings on https://github.com/ansys/openapi-common-docs and configure the CNAME in this repo settings