### PR TITLE
Fix labelling workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,27 @@
+- name: bug
+  description: Something isn't working
+  color: d42a34
+
+- name: dependencies
+  description: Related with project dependencies
+  color: ffc0cb
+
+- name: documentation
+  description: Improvements or additions to documentation
+  color: 0677ba
+
+- name: enhancement
+  description: New features or code improvements
+  color: FFD827
+
+- name: good first issue
+  description: Easy to solve for newcomers
+  color: 62ca50
+
+- name: maintenance
+  description: Package and maintenance related
+  color: f78c37
+
+- name: release
+  description: Anything related to an incoming release
+  color: ffffff

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -4,6 +4,9 @@ on:
     types: [opened, reopened, synchronize, edited, labeled]
   push:
     branches: [ main ]
+    paths:
+      - '../labels.yml'
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -14,6 +14,15 @@ concurrency:
 
 jobs:
 
+  label-syncer:
+    name: Syncer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   labeler:
     name: Set labels
     permissions:

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -29,6 +29,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
 
     - name: Label based on changed files and branch name
@@ -53,13 +54,13 @@ jobs:
           - [maintenance](https://github.com/ansys/openapi-common/pulls?q=label%3Amaintenance+)
 
   changelog-fragment:
-      name: "Create changelog fragment"
-      needs: [labeler]
-      permissions:
-        contents: write
-        pull-requests: write
-      runs-on: ubuntu-latest
-      steps:
-      - uses: ansys/actions/doc-changelog@v6
-        with:
-          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+    name: "Create changelog fragment"
+    needs: [labeler]
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: ansys/actions/doc-changelog@v6
+      with:
+        token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}

--- a/doc/changelog.d/581.changed.md
+++ b/doc/changelog.d/581.changed.md
@@ -1,0 +1,1 @@
+Fix labelling workflow


### PR DESCRIPTION
Closes #582 

The labelling workflow currently runs on pushes to main. This should only happen if the labels.yml file (which is also missing) is updated.

This PR makes the following changes:

* Add the label definition, copied from grantami-recordlists
* Only trigger on pushes to main if the label definition is modified
* Only run the labeler step for pull requests (i.e. not for pushes)

Assuming this works as expected, we should copy these changes to the other repos