### PR TITLE
Don't generate changelog fragments for dependabot PRs

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -60,6 +60,7 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') }}
     steps:
     - uses: ansys/actions/doc-changelog@v6
       with:

--- a/doc/changelog.d/587.changed.md
+++ b/doc/changelog.d/587.changed.md
@@ -1,0 +1,1 @@
+Don't run changelog-fragment on dependabot PRs

--- a/doc/changelog.d/587.changed.md
+++ b/doc/changelog.d/587.changed.md
@@ -1,1 +1,1 @@
-Don't run changelog-fragment on dependabot PRs
+Don't generate changelog fragments for dependabot PRs


### PR DESCRIPTION
Closes #586 

Skips generation of changelog fragments for dependabot PRs