### PR TITLE
Fix dependabot-autoapprove workflow

### DIFF
--- a/.github/workflows/dependabot_approve.yml
+++ b/.github/workflows/dependabot_approve.yml
@@ -8,9 +8,6 @@ jobs:
     # Checking the author will prevent your Action run failing on non-Dependabot PRs
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
     steps:
-      - name: Dependabot metadata
-        id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v2.2.0
       - uses: actions/checkout@v4
       - name: Approve a PR if not already approved
         run: |


### PR DESCRIPTION
Fix dependabot auto-approve workflow by deleting unnecessary workflow step.

This step isn't used for anything, but fails for a non-dependabot PR.