### PR TITLE
Use PyPI Trusted Publisher approach for releases

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -154,6 +154,7 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build-library, update-changelog]
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -154,13 +154,15 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build-library, update-changelog]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
     steps:
       - uses: ansys/actions/release-pypi-public@v7
         name: "Release to public PyPI"
         with:
           library-name: ${{ env.LIBRARY_NAME }}
-          twine-username: "__token__"
-          twine-token: ${{ secrets.PYPI_TOKEN }}
+          use-trusted-publisher: true
 
       - uses: ansys/actions/release-github@v7
         name: "Release to GitHub"

--- a/doc/changelog.d/646.maintenance.md
+++ b/doc/changelog.d/646.maintenance.md
@@ -1,0 +1,1 @@
+Use PyPI Trusted Publisher approach for releases


### PR DESCRIPTION
Closes #598 

Use Trusted Publisher instead of the previous token approach. I have defined an environment that:

* Requires approval from one other member of the maintainer team
* Only runs from a release/* branch