### PR TITLE
Fix GitHub Actions syntax for doc-deploy-changelog action

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -147,7 +147,7 @@ jobs:
     steps:
       - uses: ansys/actions/doc-deploy-changelog@v7
         with:
-          token: ${{ '{{ secrets.PYANSYS_CI_BOT_TOKEN }}' }}
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
 
   release:
     name: "Release"

--- a/doc/changelog.d/648.maintenance.md
+++ b/doc/changelog.d/648.maintenance.md
@@ -1,0 +1,1 @@
+Fix GitHub Actions syntax for doc-deploy-changelog action


### PR DESCRIPTION
Fixes the syntax used to provide the token to the doc-deploy-changelog action. This mirrors the fix made directly in the release/2.1 branch.