### PR TITLE
Allow packages to build documentation if they inherit classes in this package

### DIFF
--- a/doc/changelog.d/651.fixed.md
+++ b/doc/changelog.d/651.fixed.md
@@ -1,1 +1,1 @@
-Ensure directives included in docstrings support subclassing by other packages
+Allow packages to build documentation if they inherit classes in this package

--- a/doc/changelog.d/651.fixed.md
+++ b/doc/changelog.d/651.fixed.md
@@ -1,0 +1,1 @@
+Ensure directives included in docstrings support subclassing by other packages

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -22,9 +22,8 @@ sys.path.insert(0, os.path.abspath("../src"))
 # The short X.Y version
 release = version = common.__version__
 
-# Add the openapi-common-standalone tag to indicate the docs should be built
-# in standalone mode
-tags.add("openapi-common-standalone")
+# Add a tag to indicate the docs should be built in standalone mode
+tags.add("OpenapiCommonStandaloneBuild")
 
 # -- General configuration ---------------------------------------------------
 extensions = [

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -50,6 +50,7 @@ autodoc_typehints_description_target = "documented"
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.11", None),
     "requests": ("https://requests.readthedocs.io/en/latest", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
 }
 
 # numpydoc configuration

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -3,6 +3,10 @@ import os
 import sys
 
 from ansys_sphinx_theme import get_version_match
+from sphinx.errors import NoUri
+from sphinx.util import logging
+
+logger = logging.getLogger(__name__)
 
 from ansys.openapi import common
 
@@ -17,6 +21,10 @@ sys.path.insert(0, os.path.abspath("../src"))
 
 # The short X.Y version
 release = version = common.__version__
+
+# Add the openapi-common-standalone tag to indicate the docs should be built
+# in standalone mode
+tags.add("openapi-common-standalone")
 
 # -- General configuration ---------------------------------------------------
 extensions = [
@@ -137,3 +145,19 @@ html_theme_options = {
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "openapicommondoc"
+
+
+# -- Suppress warnings raised by missing xrefs to intersphinx link to this documentation when generating docs --
+def suppress_missing_intersphinx_xrefs(app, env, node, contnode):
+    ref_target = node.attributes["reftarget"]
+    if ref_target.startswith("openapi-common"):
+        ref_doc = node.attributes["refdoc"]
+        logger.info(
+            f"Suppressing warning for missing intersphinx xref from {ref_doc} to {ref_target}"
+        )
+        raise NoUri
+
+
+def setup(app):
+    logger.info("Registering 'suppress_missing_intersphinx_xrefs' callback")
+    app.connect("missing-reference", suppress_missing_intersphinx_xrefs)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -3,10 +3,6 @@ import os
 import sys
 
 from ansys_sphinx_theme import get_version_match
-from sphinx.errors import NoUri
-from sphinx.util import logging
-
-logger = logging.getLogger(__name__)
 
 from ansys.openapi import common
 
@@ -145,19 +141,3 @@ html_theme_options = {
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = "openapicommondoc"
-
-
-# -- Suppress warnings raised by missing xrefs to intersphinx link to this documentation when generating docs --
-def suppress_missing_intersphinx_xrefs(app, env, node, contnode):
-    ref_target = node.attributes["reftarget"]
-    if ref_target.startswith("openapi-common"):
-        ref_doc = node.attributes["refdoc"]
-        logger.info(
-            f"Suppressing warning for missing intersphinx xref from {ref_doc} to {ref_target}"
-        )
-        raise NoUri
-
-
-def setup(app):
-    logger.info("Registering 'suppress_missing_intersphinx_xrefs' callback")
-    app.connect("missing-reference", suppress_missing_intersphinx_xrefs)

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -80,7 +80,7 @@ outside of this package, always use the following approach:
 
        .. versionadded:: 2.1
 
-   .. only:: OpenapiCommonStandaloneBuild
+   .. only:: not OpenapiCommonStandaloneBuild
 
        .. tip::
           Added to :class:`~ansys.openapi.common.ClassName` in version 2.1 of

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -65,3 +65,10 @@ build process, which ensures that:
 * When building the documentation for a package that inherits from this package,
   the more generic ``.. tip::`` directive is used, and additional context about
   the change is provided.
+
+.. note::
+
+   The example code includes a link to the documentation for this package via
+   :doc:`Intersphinx <sphinx:usage/extensions/intersphinx>`. The Intersphinx
+   mapping for this package should always be set to ``openapi-common`` to
+   ensure the links included in this package are generated correctly.

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -68,36 +68,36 @@ these types via :doc:`Intersphinx <sphinx:usage/extensions/intersphinx>`.
 References to this package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Docstrings often contain implicit and explicit references to the package
-they are documenting. One common example of an implicit reference is in
+Docstrings often contain implicit and explicit references to the package they are
+documenting. One common example of an implicit reference is in
 ``.. versionadded::`` directives, where the directive implicitly refers to a version
-of this package. To make these references explicit when they occur outside of this
-package, always use the following approach:
+of the package being documented. To make these references explicit when they occur
+outside of this package, always use the following approach:
 
 .. code-block:: restructuredtext
 
-   .. only:: openapi-common-standalone
+   .. only:: OpenapiCommonStandaloneBuild
 
        .. versionadded:: 2.1
 
-   .. only:: not openapi-common-standalone
+   .. only:: OpenapiCommonStandaloneBuild
 
        .. tip::
-          Added to :doc:`ansys-openapi-common <openapi-common:index>` in version 2.1.
+          Added to :class:`~ansys.openapi.common.ClassName` in version 2.1 of
+          ``ansys-openapi-common``.
 
-
-The ``openapi-common-standalone`` tag is added automatically during the documentation
-build process, which ensures that:
+Where ``:class:`ansys.openapi.common.ClassName``` is a reference to the relevant
+entity that contains the change. This approach ensures that:
 
 * When building the documentation for this package, the ``.. versionadded::``
   directive is used and *implicitly* refers to version 2.1 of this package.
-* When building the documentation for a package that inherits from this package,
-  the more generic ``.. tip::`` directive is used, and *explicitly* refers to
-  version 2.1 of this package with a hyperlink to provide additional context.
+* When building the documentation for a package that inherits from classes
+  defined in this package, the more generic ``.. tip::`` directive is used,
+  and *explicitly* refers to version 2.1 of this package.
 
 .. note::
 
-   The example code includes a link to the documentation for this package via
-   :doc:`Intersphinx <sphinx:usage/extensions/intersphinx>`. The Intersphinx
-   mapping for this package should always be set to ``openapi-common`` to
-   ensure the links included in this package are generated correctly.
+   If the inheriting package has configured
+   :doc:`Intersphinx <sphinx:usage/extensions/intersphinx>`, then Sphinx will
+   automatically add a cross-reference to the relevant location in the API
+   documentation for this package.

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -10,7 +10,6 @@ with this guide before attempting to contribute to OpenAPI-Common.
 
 The following contribution information is specific to OpenAPI-Common.
 
-
 Clone the repository
 --------------------
 
@@ -26,7 +25,43 @@ run:
 
 Post issues
 -----------
+
 Use the `OpenAPI-Common Issues <https://github.com/pyansys/openapi-common/issues>`_ page
 to submit questions, report bugs, and request new features.
 
 To reach the support team, email `pyansys.support@ansys.com <pyansys.support@ansys.com>`_.
+
+
+Documentation conventions
+-------------------------
+
+When contributing to this package, always consider that many docstrings are viewed within
+the context of a package that inherits from classes defined in this package. For example,
+:class:`~ansys.openapi.common.ApiClientFactory` is typically subclassed, and the builder
+methods are shown within the sub-classing package's documentation as part of **that**
+module's subclass.
+
+One common example of where this is important is in ``.. versionadded::`` directives.
+To document that a certain feature was added in version 2.1 of ``ansys.openapi.common``,
+always use the following approach:
+
+.. code-block:: restructuredtext
+
+   .. only:: openapi-common-standalone
+
+       .. versionadded:: 2.1
+
+   .. only:: not openapi-common-standalone
+
+       .. tip::
+          Added to :doc:`ansys-openapi-common <openapi-common:index>` in version 2.1.
+
+
+The ``openapi-common-standalone`` tag is added automatically during the documentation
+build process, which ensures that:
+
+* When building the documentation for this package, the ``.. versionadded::``
+  directive is used.
+* When building the documentation for a package that inherits from this package,
+  the more generic ``.. tip::`` directive is used, and additional context about
+  the change is provided.

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -98,6 +98,6 @@ entity that contains the change. This approach ensures that:
 .. note::
 
    If the inheriting package has configured
-   :doc:`Intersphinx <sphinx:usage/extensions/intersphinx>`, then Sphinx will
-   automatically add a cross-reference to the relevant location in the API
+   :doc:`Intersphinx <sphinx:usage/extensions/intersphinx>`, then Sphinx
+   automatically adds a cross-reference to the relevant location in the API
    documentation for this package.

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -39,10 +39,37 @@ When contributing to this package, always consider that many docstrings are view
 the context of a package that inherits from classes defined in this package. For example,
 :class:`~ansys.openapi.common.ApiClientFactory` is typically subclassed, and the builder
 methods are shown within the sub-classing package's documentation as part of **that**
-module's subclass.
+module's subclass. The advice in this section ensures that a sub-classing package can
+build documentation that inherits docstrings from this package.
 
-One common example of where this is important is in ``.. versionadded::`` directives.
-To document that a certain feature was added in version 2.1 of ``ansys.openapi.common``,
+Docstring type references
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In cases where a class is intended to be subclassed, internal type references should be
+fully qualified. For example, instead of::
+
+    Parameters
+    ----------
+    authentication_scheme : AuthenticationScheme
+        The authentication scheme to use.
+
+use::
+
+    Parameters
+    ----------
+    authentication_scheme : ~ansys.openapi.common.AuthenticationScheme
+        The authentication scheme to use.
+
+This ensures that other packages that inherit from this package are able to resolve
+these types via :doc:`Intersphinx <sphinx:usage/extensions/intersphinx>`.
+
+References to this package
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Docstrings often contain implicit and explicit references to the package they are
+documenting. One common example of an implicit reference is in ``.. versionadded::``
+directives, where the directive implicitly refers to a version of this package.
+To make these references explicit when they occur outside of this package,
 always use the following approach:
 
 .. code-block:: restructuredtext
@@ -61,10 +88,10 @@ The ``openapi-common-standalone`` tag is added automatically during the document
 build process, which ensures that:
 
 * When building the documentation for this package, the ``.. versionadded::``
-  directive is used.
+  directive is used and *implicitly* refers to version 2.1 of this package.
 * When building the documentation for a package that inherits from this package,
-  the more generic ``.. tip::`` directive is used, and additional context about
-  the change is provided.
+  the more generic ``.. tip::`` directive is used, and *explicitly* refers to
+  version 2.1 of this package with a hyperlink to provide additional context.
 
 .. note::
 

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -40,8 +40,8 @@ Documentation conventions
 When contributing to this package, always consider that many docstrings are viewed within
 the context of a package that inherits from classes defined in this package. For example,
 :class:`~.ApiClientFactory` is typically subclassed, and the builder methods are shown
-within the sub-classing package's documentation as part of **that** module's subclass.
-The advice in this section ensures that a sub-classing package can build documentation
+within the subclassing package's documentation as part of **that** module's subclass.
+The advice in this section ensures that a subclassing package can build documentation
 that inherits docstrings from this package.
 
 Docstring type references

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -1,5 +1,7 @@
 .. _contributing_openapi:
 
+.. currentmodule:: ansys.openapi.common
+
 ==========
 Contribute
 ==========
@@ -37,10 +39,10 @@ Documentation conventions
 
 When contributing to this package, always consider that many docstrings are viewed within
 the context of a package that inherits from classes defined in this package. For example,
-:class:`~ansys.openapi.common.ApiClientFactory` is typically subclassed, and the builder
-methods are shown within the sub-classing package's documentation as part of **that**
-module's subclass. The advice in this section ensures that a sub-classing package can
-build documentation that inherits docstrings from this package.
+:class:`~.ApiClientFactory` is typically subclassed, and the builder methods are shown
+within the sub-classing package's documentation as part of **that** module's subclass.
+The advice in this section ensures that a sub-classing package can build documentation
+that inherits docstrings from this package.
 
 Docstring type references
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -66,11 +68,11 @@ these types via :doc:`Intersphinx <sphinx:usage/extensions/intersphinx>`.
 References to this package
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Docstrings often contain implicit and explicit references to the package they are
-documenting. One common example of an implicit reference is in ``.. versionadded::``
-directives, where the directive implicitly refers to a version of this package.
-To make these references explicit when they occur outside of this package,
-always use the following approach:
+Docstrings often contain implicit and explicit references to the package
+they are documenting. One common example of an implicit reference is in
+``.. versionadded::`` directives, where the directive implicitly refers to a version
+of this package. To make these references explicit when they occur outside of this
+package, always use the following approach:
 
 .. code-block:: restructuredtext
 

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -8,4 +8,5 @@ OpenAPI
 THIRDPARTY
 (?i)docstrings?
 subclassed
+subclassing
 Intersphinx

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -6,3 +6,6 @@ Heimdal
 Kerberos
 OpenAPI
 THIRDPARTY
+(?i)docstrings?
+subclassed
+Intersphinx

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -86,11 +86,11 @@ class AuthenticationScheme(Enum):
 
     Used to specify an authentication scheme used when connecting to the server with credentials.
 
-    .. only:: openapi-common-standalone
+    .. only:: OpenapiCommonStandaloneBuild
 
         .. versionadded:: 2.1
 
-    .. only:: not openapi-common-standalone
+    .. only:: not OpenapiCommonStandaloneBuild
 
         .. tip::
            Added to :doc:`ansys-openapi-common <openapi-common:index>` in version 2.1.
@@ -117,7 +117,7 @@ class ApiClientFactory:
     ----------
     api_url : str
        Base URL of the API server.
-    session_configuration : SessionConfiguration, optional
+    session_configuration : ~ansys.openapi.common.SessionConfiguration, optional
        Additional configuration settings for the requests session.
     """
 
@@ -182,7 +182,7 @@ class ApiClientFactory:
 
         Returns
         -------
-        :class:`ApiClient`
+        ~ansys.openapi.common.ApiClient
             Client object that can be used to connect to the server and perform API operations.
 
         Raises
@@ -204,7 +204,7 @@ class ApiClientFactory:
 
         Returns
         -------
-        :class:`~ansys.openapi.common.ApiClientFactory`
+        ~ansys.openapi.common.ApiClientFactory
             Original client factory object.
         """
         self.__test_connection()
@@ -236,18 +236,18 @@ class ApiClientFactory:
         authentication_scheme : ~ansys.openapi.common.AuthenticationScheme
             The authentication scheme to use.
 
-            .. only:: openapi-common-standalone
+            .. only:: OpenapiCommonStandaloneBuild
 
                 .. versionadded:: 2.1
 
-            .. only:: not openapi-common-standalone
+            .. only:: not OpenapiCommonStandaloneBuild
 
                 .. tip::
                    Added to :doc:`ansys-openapi-common <openapi-common:index>` in version 2.1.
 
         Returns
         -------
-        :class:`~ansys.openapi.common.ApiClientFactory`
+        ~ansys.openapi.common.ApiClientFactory
             Original client factory object.
 
         Raises
@@ -311,7 +311,7 @@ class ApiClientFactory:
 
         Returns
         -------
-        :class:`~ansys.openapi.common.ApiClientFactory`
+        ~ansys.openapi.common.ApiClientFactory
             Current client factory object.
 
         Raises
@@ -356,12 +356,12 @@ class ApiClientFactory:
 
         Parameters
         ----------
-        idp_session_configuration : :class:`~ansys.openapi.common.SessionConfiguration`, optional
+        idp_session_configuration : ~ansys.openapi.common.SessionConfiguration, optional
             Additional configuration settings for the requests session when connected to the OpenID identity provider.
 
         Returns
         -------
-        :class:`~ansys.openapi.common.OIDCSessionBuilder`
+        ~ansys.openapi.common.OIDCSessionBuilder
             Builder object to authenticate via OIDC.
 
         Notes
@@ -475,9 +475,9 @@ class OIDCSessionBuilder:
 
     Parameters
     ----------
-    client_factory : ApiClientFactory
+    client_factory : ~ansys.openapi.common.ApiClientFactory
         Parent API client factory object that will be returned once configuration is complete.
-    session_factory : OIDCSessionFactory, optional
+    session_factory : ~ansys.openapi.common.OIDCSessionFactory, optional
         OIDC session factory object that will be configured and used to return an OAuth-supporting session.
     """
 
@@ -501,7 +501,7 @@ class OIDCSessionBuilder:
 
         Returns
         -------
-        :class:`ApiClientFactory`
+        ~ansys.openapi.common.ApiClientFactory
            Original client factory object.
 
         Raises
@@ -530,7 +530,7 @@ class OIDCSessionBuilder:
 
         Returns
         -------
-        :class:`ApiClientFactory`
+        ~ansys.openapi.common.ApiClientFactory
             Original client factory object.
         """
         if self._session_factory is None:
@@ -551,7 +551,7 @@ class OIDCSessionBuilder:
 
         Returns
         -------
-        :class:`ApiClientFactory`
+        ~ansys.openapi.common.ApiClientFactory
             Original client factory object.
         """
         if self._session_factory is None:

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -93,7 +93,8 @@ class AuthenticationScheme(Enum):
     .. only:: not OpenapiCommonStandaloneBuild
 
         .. tip::
-           Added to :doc:`ansys-openapi-common <openapi-common:index>` in version 2.1.
+           Added as :class:`~ansys.openapi.common.AuthenticationScheme` in version 2.1 of
+           ``ansys-openapi-common``.
     """
 
     AUTO = "auto"
@@ -243,7 +244,9 @@ class ApiClientFactory:
             .. only:: not OpenapiCommonStandaloneBuild
 
                 .. tip::
-                   Added to :doc:`ansys-openapi-common <openapi-common:index>` in version 2.1.
+                   Added to
+                   :meth:`ApiClientFactory.with_credentials <ansys.openapi.common.ApiClientFactory.with_credentials>`
+                   in version 2.1 of ``ansys-openapi-common``.
 
         Returns
         -------

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -86,7 +86,14 @@ class AuthenticationScheme(Enum):
 
     Used to specify an authentication scheme used when connecting to the server with credentials.
 
-    .. versionadded:: 2.1
+    .. only:: openapi-common-standalone
+
+        .. versionadded:: 2.1
+
+    .. only:: not openapi-common-standalone
+
+        .. tip::
+           Added to :doc:`ansys-openapi-common <openapi-common:index>` in version 2.1.
     """
 
     AUTO = "auto"
@@ -210,11 +217,7 @@ class ApiClientFactory:
         username: str,
         password: str,
         domain: Optional[str] = None,
-        authentication_scheme: Union[
-            Literal[AuthenticationScheme.AUTO],
-            Literal[AuthenticationScheme.BASIC],
-            Literal[AuthenticationScheme.NTLM],
-        ] = AuthenticationScheme.AUTO,
+        authentication_scheme: AuthenticationScheme = AuthenticationScheme.AUTO,
     ) -> Api_Client_Factory:
         """Set up client authentication for use with provided credentials.
 
@@ -230,13 +233,17 @@ class ApiClientFactory:
             Password for the connection.
         domain : str, optional
             Domain to use for connection if required. The default is ``None``.
-        authentication_scheme : AuthenticationScheme
-            The authentication scheme to use instead of using the ``WWW-Authenticate`` header. The default is
-            :attr:`~.AuthenticationScheme.AUTO` which uses the ``WWW-Authenticate`` header to determine the optimal
-            authentication scheme. Valid schemes for this method are :attr:`~.AuthenticationScheme.BASIC` or
-            :attr:`~.AuthenticationScheme.NTLM`.
+        authentication_scheme : ~ansys.openapi.common.AuthenticationScheme
+            The authentication scheme to use.
 
-            .. versionadded:: 2.1
+            .. only:: openapi-common-standalone
+
+                .. versionadded:: 2.1
+
+            .. only:: not openapi-common-standalone
+
+                .. tip::
+                   Added to :doc:`ansys-openapi-common <openapi-common:index>` in version 2.1.
 
         Returns
         -------


### PR DESCRIPTION
Closes #650 

This PR solves the problem of 'leaking' ansys.openapi.common documentation specifics into packages that subclass the types in this package.

# Broken xrefs
Missing xrefs in numpydoc docstrings was fixed by fully qualifying type references in docstrings for all commonly inherited classes and add a note in the contributing guide.

# Inconsistent versionadded directives
This is achieved by wrapping `.. versionadded::` ReStructuredText directives in a pair of `.. only::` blocks that serve to switch the documentation behavior depending on whether a tag is present or not. If the tag is present, it is assumed that we are building 'standalone' docs, i.e. docs for this package, and the versionadded directive is included. If the tag is not present, it is assumed we are building docs for some other package that inherit docstrings from this package. In this case, we use an `.. info::` directive and include a link to the openapi docs for context.

Also requires a sphinx conf.py changes to add the tag automatically during the build.