### PR TITLE
Bump version to 2.3

### DIFF
--- a/doc/changelog.d/699.maintenance.md
+++ b/doc/changelog.d/699.maintenance.md
@@ -1,0 +1,1 @@
+Bump version to 2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "ansys-openapi-common"
 description = "Provides a helper to create sessions for use with Ansys OpenAPI clients."
-version = "2.1.0"
+version = "2.3.0"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
There were no dev docs published with version 2.2, so they're still on 2.1 which is a bit confusing. This bumps the version to 2.3.
