### PR TITLE
Reorganize documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,169 +29,70 @@
    :alt: pre-commit.ci status
 
 
-Overview
---------
+OpenAPI-Common
+==============
 
-OpenAPI-Common is intended for use with the custom code generation
+..
+   _after-badges
+
+OpenAPI Common is designed for use with the custom code generation
 template in the `PyAnsys project <https://github.com/pyansys>`_.
-It provides the source code for an authentication-aware
-client for OpenAPI client libraries.
+It provides the source code for an authentication-aware client for
+OpenAPI client libraries.
+
+Background
+----------
+A widely used standard for HTTP REST-style APIs is the OpenAPI standard,
+formerly known as Swagger. OpenAPI-Common is designed to be used alongside
+code generation tools to produce client libraries for HTTP APIs.
+
+Because some Ansys products expose HTTP APIs rather than gRPC
+APIs, this Python library provides a common client to consume
+HTTP APIs, minimizing overhead and reducing code duplication.
 
 OpenAPI-Common supports authentication with Basic, Negotiate, NTLM,
 and OpenID Connect. Most features of the underlying requests session
 are exposed for use. Some basic configuration is also provided by default.
 
+Dependencies
+------------
+.. readme_software_requirements
+
+The ``ansys.openapi.common`` package currently supports Python version 3.10 through 3.13.
+
+See the :ref:`User Guide <ref_user_guide>` for platform-specific Kerberos requirements.
+
+.. readme_software_requirements_end
+
 Installation
 ------------
+.. readme_installation
 
-Install the ``openapi-common`` repository with this code:
-
-.. code::
-
-   pip install ansys-openapi-common
-
-Alternatively, clone and install the repository with this code:
+To install the latest OpenAPI-Common release from `PyPI <https://pypi.org/project/ansys-openapi-common/>`_,
+run this command:
 
 .. code::
 
-   git clone https://github.com/pyansys/openapi-common
-   cd openapi-common
-   pip install .
+    pip install ansys-openapi-common
+
+Alternatively, to install the latest development version from the `OpenAPI-Common repository <https://github.com/ansys/openapi-common>`_,
+run this command:
+
+.. code::
+
+    pip install git+https://github.com/ansys/openapi-common.git
 
 
-Usage
------
+To install a local *development* version with Git and Poetry, run these commands:
 
-The API client class is intended to be wrapped by code that implements a client library.
-You should override the ``__init__()`` or ``connect()`` method to add any
-additional behavior that might be required.
+.. code::
 
-Authentication is configured through the ``ApiClientFactory`` object and its ``with_xxx()``
-methods. If no authentication is required, you can use the ``with_anonymous()`` method.
-You can provide additional configuration with the ``SessionConfiguration`` object.
-
-.. code:: python
-
-   >>> from ansys.openapi.common import ApiClientFactory
-   >>> session = ApiClientFactory('https://my-api.com/v1.svc')
-   ...           .with_autologon()
-   ...           .connect()
-   <ApiClient url: https://my-api.com/v1.svc>
+    git clone https://github.com/ansys/openapi-common
+    cd openapi-common
+    poetry install
 
 
-Authentication schemes
-----------------------
+The preceding commands install the package in development mode so that you can modify
+it locally. Your changes are reflected in your Python setup after restarting the Python kernel.
 
-OpenAPI-Common supports API servers configured with no authentication, API keys,
-client certificates, and basic authentication schemes.
-
-Windows users can also use Windows Integrated Authentication to connect to Kerberos-enabled
-APIs with their Windows credentials and to NTLM where it is supported.
-
-Linux users can make use of Kerberos authentication via the ``[linux-kerberos]`` extra. This
-requires a working installation of either MIT Kerberos or Heimdal, as well as some
-platform-specific build steps. An additional requirement is a correctly configured ``krb5.keytab``
-file on your system.
-
-Windows and Linux users can authenticate with OIDC-enabled APIs by using the ``[oidc]`` extra.
-Currently only the Authorization Code authentication flow is supported.
-
-.. list-table:: Authentication methods by platform
-   :header-rows: 1
-
-   * - Authentication method
-     - Windows
-     - Linux
-     - Builder method
-     - Additional settings
-   * - API Key
-     - ✔️
-     - ✔️
-     - ``.with_anonymous()``
-     - Set the appropriate header in ``api_session_configuration``
-   * - Client Certificate
-     - ✔️
-     - ✔️
-     - Any
-     - Provide ``client_cert_path`` and optionally ``client_cert_key`` in ``api_session_configuration``
-   * - Basic
-     - ✔️
-     - ✔️
-     - ``.with_credentials()``
-     -
-   * - NTLM
-     - ✔️
-     - ❌
-     - ``.with_credentials()``
-     -
-   * - Kerberos
-     - ✔️
-     - ➕ with ``[linux-kerberos]`` extra
-     - ``.with_autologon()``
-     -
-   * - OIDC
-     - ➕ with ``[oidc]`` extra
-     - ➕ with ``[oidc]`` extra
-     - ``.with_oidc()``
-     -
-
-HTTPS Certificates
-~~~~~~~~~~~~~~~~~~
-
-The ``requests`` library uses the ``certifi`` package to verify TLS certificates instead of a local system certificate store.
-These means only TLS certificates signed by a public CA can be verified by ``requests`` in its default configuration. If you
-need to verify internally-signed TLS certificates, there are two recommended approaches:
-
-pip-system-certs
-================
-
-The ``pip-system-certs`` library patches the certificate loading mechanism for ``requests`` causing it to
-use your system certificate store. This is the simplest solution, but there are two potential limitations:
-
-1. ``pip-system-certs`` does not support every platform that is supported by CPython, so it may not
-be supported on your platform.
-
-2. The change to ``requests`` affects every package in your environment, including pip. Make sure you are
-using a virtual environment.
-
-.. note::
-  If you are using OIDC authentication and your service provides a internally-signed certificate you will need
-  to use this option.
-
-Custom certificate store
-========================
-
-The ``SessionConfiguration`` object allows you to provide a path to a custom CA certificate. If provided, this will be
-used to verify the service's TLS certificate instead of the ``certifi`` package.
-
-Platform-specific Kerberos configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Kerberos authentication should be supported wherever the MIT or Heimdal Kerberos client
-can be installed. OpenAPI-Common has been tested on the platforms that follow.
-If you manage to use it on another platform, consider contributing installation steps for
-your platform by making a pull request.
-
-Ubuntu 20.04
-============
-
-Ubuntu requires the ``gssapi`` Python module to be built from source. This requires the
-Kerberos headers, Python headers for the version of Python that you are using (here we have
-installed python3.10 from the deadsnakes ppa), and a supported compiler. (GCC works well.))
-
-You should then be able to install this module with the ``[linux-kerberos]`` extra.
-
-.. code-block:: bash
-
-   sudo apt install build-essential python3.10-dev libkrb5-dev
-   pip install ansys-openapi-common[linux-kerberos]
-
-
-Once the installation completes, ensure that your ``krb5.conf`` file is set up correctly
-for your Kerberos configuration and that you have a valid ``keytab`` file, which is
-normally in ``/etc/krb5.keytab``.
-
-License
--------
-OpenAPI-Common is provided under the terms of the MIT license. You can find
-the license text in the LICENSE file at the root of the repository.
+.. readme_installation_end

--- a/README.rst
+++ b/README.rst
@@ -60,9 +60,39 @@ Dependencies
 
 The ``ansys.openapi.common`` package currently supports Python version 3.10 through 3.13.
 
-See the :ref:`User Guide <ref_user_guide>` for platform-specific Kerberos requirements.
-
 .. readme_software_requirements_end
+
+Platform-specific Kerberos configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. readme_kerberos
+
+Kerberos authentication should be supported wherever the MIT or Heimdal Kerberos client
+can be installed. OpenAPI-Common has been tested on the platforms that follow.
+If you manage to use it on another platform, consider contributing installation steps for
+your platform by making a pull request.
+
+Ubuntu 20.04
+^^^^^^^^^^^^
+
+Ubuntu requires the ``gssapi`` Python module to be built from source. This requires the
+Kerberos headers, Python headers for the version of Python that you are using, and a
+supported compiler. (GCC works well.)
+
+You should then be able to install this module with the ``[linux-kerberos]`` extra:
+
+.. code-block:: sh
+
+   sudo apt install build-essentials python3.8-dev libkrb5-dev
+   pip install ansys-openapi-common[linux-kerberos]
+
+
+Once the installation completes, ensure that your ``krb5.conf`` file is set up correctly
+for your Kerberos configuration and that you have a valid ``keytab`` file, which is
+normally in ``/etc/krb5.keytab``.
+
+.. readme_kerberos_end
+
 
 Installation
 ------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx.ext.extlinks",
     "sphinx.ext.coverage",
+    "sphinx_design",
 ]
 
 # Sphinx

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -86,7 +86,7 @@ outside of this package, always use the following approach:
           Added to :class:`~ansys.openapi.common.ClassName` in version 2.1 of
           ``ansys-openapi-common``.
 
-Where :class:`ansys.openapi.common.ClassName` is a reference to the relevant
+Where ``:class:`ansys.openapi.common.ClassName``` is a reference to the relevant
 entity that contains the change. This approach ensures that:
 
 * When building the documentation for this package, the ``.. versionadded::``

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -86,7 +86,7 @@ outside of this package, always use the following approach:
           Added to :class:`~ansys.openapi.common.ClassName` in version 2.1 of
           ``ansys-openapi-common``.
 
-Where ``:class:`ansys.openapi.common.ClassName``` is a reference to the relevant
+Where :class:`ansys.openapi.common.ClassName` is a reference to the relevant
 entity that contains the change. This approach ensures that:
 
 * When building the documentation for this package, the ``.. versionadded::``

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -1,0 +1,37 @@
+.. _ref_getting_started:
+
+Getting started
+###############
+
+.. _ref_software_requirements:
+
+Software requirements
+~~~~~~~~~~~~~~~~~~~~~~
+.. include:: ../../../README.rst
+      :start-after: readme_software_requirements
+      :end-before: readme_software_requirements_end
+
+
+Installation
+~~~~~~~~~~~~
+.. include:: ../../../README.rst
+      :start-after: readme_installation
+      :end-before: readme_installation_end
+
+
+Brief example
+~~~~~~~~~~~~~
+This brief example demonstrates how the client works:
+
+.. code:: python
+
+    >>> from ansys.openapi.common import ApiClientFactory
+    >>> client = ApiClientFactory("https://my-api.com")
+    ...          .with_autologon()
+    ...          .connect()
+    >>> print(client)
+
+    <ApiClient url: http://my-api.com>
+
+
+The client is now ready and available for use with an OpenAPI client.

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -35,3 +35,9 @@ This brief example demonstrates how the client works:
 
 
 The client is now ready and available for use with an OpenAPI client.
+
+Platform-specific Kerberos configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. include:: ../../../README.rst
+      :start-after: readme_kerberos
+      :end-before: readme_kerberos_end

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,152 +1,47 @@
 OpenAPI-Common |version|
 ========================
 
+OpenAPI-Common is part of the larger `PyAnsys <https://docs.pyansys.com>`_
+effort to facilitate the use of Ansys technologies directly from Python.
+
+.. grid:: 1 2 2 2
+
+
+   .. grid-item-card:: Getting started :material-regular:`directions_run`
+      :padding: 2 2 2 2
+      :link: getting_started/index
+      :link-type: doc
+
+      Learn how to install OpenAPI-Common.
+
+   .. grid-item-card:: User guide :material-regular:`menu_book`
+      :padding: 2 2 2 2
+      :link: user_guide/index
+      :link-type: doc
+
+      Understand how to use OpenAPI-Common as a base for OpenAPI-based
+      client applications.
+
+   .. grid-item-card:: API reference :material-regular:`bookmark`
+      :padding: 2 2 2 2
+      :link: api/index
+      :link-type: doc
+
+      Understand the classes and methods that make up OpenAPI-Common.
+
+   .. grid-item-card:: Contribute :material-regular:`group`
+      :padding: 2 2 2 2
+      :link: contributing
+      :link-type: doc
+
+      Learn how to contribute to the OpenAPI-Common codebase or documentation.
+
+
 .. toctree::
    :hidden:
    :maxdepth: 3
 
+   getting_started/index
+   user_guide/index
    api/index
    contributing
-
-
-Introduction
-------------
-OpenAPI-Common is part of the larger `PyAnsys <https://docs.pyansys.com>`_
-effort to facilitate the use of Ansys technologies directly from Python.
-
-Because some Ansys products expose HTTP APIs rather than gRPC
-APIs, this Python library provides a common client to consume
-HTTP APIs, minimizing overhead and reducing code duplication.
-
-
-Background
-----------
-A widely used standard for HTTP REST-style APIs is the OpenAPI standard,
-formerly known as Swagger. OpenAPI-Common is designed to be used alongside
-code generation tools to produce client libraries for HTTP APIs.
-
-
-Brief example
--------------
-This brief example demonstrates how the client works:
-
-.. code:: python
-
-    >>> from ansys.openapi.common import ApiClientFactory
-    >>> client = ApiClientFactory("https://my-api.com")
-    ...          .with_autologon()
-    ...          .connect()
-    >>> print(client)
-
-    <ApiClient url: http://my-api.com>
-
-
-The client is now ready and available for use with an OpenAPI client.
-
-Authentication schemes
-----------------------
-OpenAPI-Common supports API servers configured with no authentication, API keys,
-client certificates, and basic authentication.
-
-Windows users can also use Windows Integrated Authentication to connect to Kerberos-enabled
-APIs with their Windows credentials and to NTLM where it is supported.
-
-Linux users can make use of Kerberos authentication via the ``[linux-kerberos]`` extra. This
-requires a working installation of either MIT Kerberos or Heimdal, as well as some
-platform-specific build steps. An additional requirement is a correctly configured ``krb5.keytab``
-file on your system.
-
-Windows and Linux users can authenticate with OIDC-enabled APIs by using the ``[oidc]`` extra.
-Currently only the Authorization Code authentication flow is supported.
-
-.. list-table:: Authentication methods by platform
-   :header-rows: 1
-   :widths: 30 15 15 40
-
-   * - Authentication method
-     - Windows
-     - Linux
-     - Builder method
-   * - API Key
-     - ✔️
-     - ✔️
-     - ``.with_anonymous()`` [1]_
-   * - Basic
-     - ✔️
-     - ✔️
-     - ``.with_credentials()``
-   * - NTLM
-     - ✔️
-     - ❌
-     - ``.with_credentials()``
-   * - Kerberos
-     - ✔️
-     - ➕ [2]_
-     - ``.with_autologon()``
-   * - OIDC
-     - ➕ [3]_
-     - ➕ [3]_
-     - ``.with_oidc()``
-
-.. [1] Set the appropriate header in ``api_session_configuration``.
-.. [2] When installed as ``pip install ansys-openapi-common[linux-kerberos]``.
-.. [3] When installed as ``pip install ansys-openapi-common[oidc]``.
-
-Advanced features
------------------
-You can set all options that are available in Python library *requests* through
-the client. This enables you to configure custom SSL certificate validation, send
-client certificates if your API server requires them, and configure many other options.
-
-For example, to send a client certificate with every request:
-
-.. code:: python
-
-   >>> from ansys.openapi.common import SessionConfiguration
-   >>> configuration = SessionConfiguration(
-   ...    client_cert_path='./my-client-cert.pem',
-   ...    client_cert_key='secret-key'
-   ... )
-   >>> client.configuration = configuration
-
-
-Platform-specific Kerberos configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Kerberos authentication should be supported wherever the MIT or Heimdal Kerberos client
-can be installed. OpenAPI-Common has been tested on the platforms that follow.
-If you manage to use it on another platform, consider contributing installation steps for
-your platform by making a pull request.
-
-Ubuntu 20.04
-^^^^^^^^^^^^
-
-Ubuntu requires the ``gssapi`` Python module to be built from source. This requires the
-Kerberos headers, Python headers for the version of Python that you are using, and a
-supported compiler. (GCC works well.)
-
-You should then be able to install this module with the ``[linux-kerberos]`` extra:
-
-.. code-block:: sh
-
-   sudo apt install build-essentials python3.8-dev libkrb5-dev
-   pip install ansys-openapi-common[linux-kerberos]
-
-
-Once the installation completes, ensure that your ``krb5.conf`` file is set up correctly
-for your Kerberos configuration and that you have a valid ``keytab`` file, which is
-normally in ``/etc/krb5.keytab``.
-
-API reference
--------------
-For comprehensive API documentation, see :doc:`API reference <api/index>`.
-
-Contributions
--------------
-Contributions to this library are welcome. For more information, see
-:ref:`contributing_openapi`.
-
-Project index
--------------
-
-* :ref:`genindex`

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -1,0 +1,150 @@
+.. _ref_user_guide:
+
+.. currentmodule:: ansys.openapi.common
+
+User guide
+##########
+
+Basic usage
+-----------
+
+The :class:`.ApiClient` class is designed to be wrapped by code that implements a client
+library. You should override the :meth:`~.ApiClient.__init__` or :meth:`~.connect` methods
+to add additional required behavior.
+
+Authentication is configured through the :class:`.ApiClientFactory` object and its
+``with_xxx()`` methods. If no authentication is required, you can use the
+:meth:`~.ApiClientFactory.with_anonymous()` method. You can provide additional
+configuration with the :class:`~.SessionConfiguration` object.
+
+.. code:: python
+
+   >>> from ansys.openapi.common import ApiClientFactory
+   >>> session = ApiClientFactory('https://my-api.com/v1.svc')
+   ...           .with_autologon()
+   ...           .connect()
+   <ApiClient url: https://my-api.com/v1.svc>
+
+
+Authentication schemes
+----------------------
+OpenAPI-Common supports API servers configured with no authentication, API keys,
+client certificates, and basic authentication.
+
+Windows users can also use Windows Integrated Authentication to connect to Kerberos-enabled
+APIs with their Windows credentials and to NTLM where it is supported.
+
+Linux users can make use of Kerberos authentication via the ``[linux-kerberos]`` extra. This
+requires a working installation of either MIT Kerberos or Heimdal, as well as some
+platform-specific build steps. An additional requirement is a correctly configured ``krb5.keytab``
+file on your system.
+
+Windows and Linux users can authenticate with OIDC-enabled APIs by using the ``[oidc]`` extra.
+Currently only the Authorization Code authentication flow is supported.
+
+.. list-table:: Authentication methods by platform
+   :header-rows: 1
+   :widths: 30 15 15 40
+
+   * - Authentication method
+     - Windows
+     - Linux
+     - Builder method
+   * - API Key
+     - ✔️
+     - ✔️
+     - ``.with_anonymous()`` [1]_
+   * - Basic
+     - ✔️
+     - ✔️
+     - ``.with_credentials()``
+   * - NTLM
+     - ✔️
+     - ❌
+     - ``.with_credentials()``
+   * - Kerberos
+     - ✔️
+     - ➕ [2]_
+     - ``.with_autologon()``
+   * - OIDC
+     - ➕ [3]_
+     - ➕ [3]_
+     - ``.with_oidc()``
+
+.. [1] Set the appropriate header in ``api_session_configuration``.
+.. [2] When installed as ``pip install ansys-openapi-common[linux-kerberos]``.
+.. [3] When installed as ``pip install ansys-openapi-common[oidc]``.
+
+HTTPS Certificates
+------------------
+
+The ``requests`` library uses the ``certifi`` package to verify TLS certificates instead of a local system certificate
+store. These means only TLS certificates signed by a public CA can be verified by ``requests`` in its default
+configuration. If you need to verify internally-signed TLS certificates, there are two recommended approaches:
+
+pip-system-certs
+~~~~~~~~~~~~~~~~
+
+The ``pip-system-certs`` library patches the certificate loading mechanism for ``requests`` causing it to
+use your system certificate store. This is the simplest solution, but there are two potential limitations:
+
+1. ``pip-system-certs`` does not support every platform that is supported by CPython, so it may not
+be supported on your platform.
+
+2. The change to ``requests`` affects every package in your environment, including pip. Make sure you are
+using a virtual environment.
+
+.. note::
+  If you are using OIDC authentication and your service provides a internally-signed certificate you will need
+  to use this option.
+
+Custom certificate store
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``SessionConfiguration`` object allows you to provide a path to a custom CA certificate. If provided, this will be
+used to verify the service's TLS certificate instead of the ``certifi`` package.
+
+Advanced features
+-----------------
+You can set all options that are available in Python library *requests* through
+the client. This enables you to configure custom SSL certificate validation, send
+client certificates if your API server requires them, and configure many other options.
+
+For example, to send a client certificate with every request:
+
+.. code:: python
+
+   >>> from ansys.openapi.common import SessionConfiguration
+   >>> configuration = SessionConfiguration(
+   ...    client_cert_path='./my-client-cert.pem',
+   ...    client_cert_key='secret-key'
+   ... )
+   >>> client.configuration = configuration
+
+
+Platform-specific Kerberos configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Kerberos authentication should be supported wherever the MIT or Heimdal Kerberos client
+can be installed. OpenAPI-Common has been tested on the platforms that follow.
+If you manage to use it on another platform, consider contributing installation steps for
+your platform by making a pull request.
+
+Ubuntu 20.04
+^^^^^^^^^^^^
+
+Ubuntu requires the ``gssapi`` Python module to be built from source. This requires the
+Kerberos headers, Python headers for the version of Python that you are using, and a
+supported compiler. (GCC works well.)
+
+You should then be able to install this module with the ``[linux-kerberos]`` extra:
+
+.. code-block:: sh
+
+   sudo apt install build-essentials python3.8-dev libkrb5-dev
+   pip install ansys-openapi-common[linux-kerberos]
+
+
+Once the installation completes, ensure that your ``krb5.conf`` file is set up correctly
+for your Kerberos configuration and that you have a valid ``keytab`` file, which is
+normally in ``/etc/krb5.keytab``.

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -75,12 +75,12 @@ Currently only the Authorization Code authentication flow is supported.
 .. [2] When installed as ``pip install ansys-openapi-common[linux-kerberos]``.
 .. [3] When installed as ``pip install ansys-openapi-common[oidc]``.
 
-HTTPS Certificates
+HTTPS certificates
 ------------------
 
 The ``requests`` library uses the ``certifi`` package to verify TLS certificates instead of a local system certificate
 store. These means only TLS certificates signed by a public CA can be verified by ``requests`` in its default
-configuration. If you need to verify internally-signed TLS certificates, there are two recommended approaches:
+configuration. If you need to verify internally signed TLS certificates, there are two recommended approaches:
 
 pip-system-certs
 ~~~~~~~~~~~~~~~~
@@ -95,14 +95,14 @@ be supported on your platform.
 using a virtual environment.
 
 .. note::
-  If you are using OIDC authentication and your service provides a internally-signed certificate you will need
-  to use this option.
+  If you are using OIDC authentication and your service provides a internally signed certificate you must
+  use this option.
 
 Custom certificate store
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``SessionConfiguration`` object allows you to provide a path to a custom CA certificate. If provided, this will be
-used to verify the service's TLS certificate instead of the ``certifi`` package.
+The ``SessionConfiguration`` object allows you to provide a path to a custom CA certificate. If provided, the
+custom CA certificate is used to verify the service's TLS certificate instead of the ``certifi`` package.
 
 Advanced features
 -----------------

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -114,7 +114,7 @@ be supported on your platform.
 using a virtual environment.
 
 .. note::
-  If you are using OIDC authentication and your service provides a internally signed certificate you must
+  If you are using OIDC authentication and your service provides an internally signed certificate you must
   use this option.
 
 Custom certificate store

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -14,8 +14,7 @@ to add additional required behavior.
 
 Authentication is configured through the :class:`.ApiClientFactory` object and its
 ``with_xxx()`` methods. If no authentication is required, you can use the
-:meth:`~.ApiClientFactory.with_anonymous()` method. You can provide additional
-configuration with the :class:`~.SessionConfiguration` object.
+:meth:`~.ApiClientFactory.with_anonymous()` method.
 
 .. code:: python
 
@@ -75,6 +74,26 @@ Currently only the Authorization Code authentication flow is supported.
 .. [2] When installed as ``pip install ansys-openapi-common[linux-kerberos]``.
 .. [3] When installed as ``pip install ansys-openapi-common[oidc]``.
 
+
+Session configuration
+---------------------
+You can set all options that are available in Python library *requests* through
+the client with the :class:`~.SessionConfiguration` object. This enables you to
+configure custom SSL certificate validation, send client certificates if your API
+server requires them, and configure many other options.
+
+For example, to send a client certificate with every request:
+
+.. code:: python
+
+   >>> from ansys.openapi.common import SessionConfiguration
+   >>> configuration = SessionConfiguration(
+   ...    client_cert_path='./my-client-cert.pem',
+   ...    client_cert_key='secret-key'
+   ... )
+   >>> client.configuration = configuration
+
+
 HTTPS certificates
 ------------------
 
@@ -101,50 +120,5 @@ using a virtual environment.
 Custom certificate store
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``SessionConfiguration`` object allows you to provide a path to a custom CA certificate. If provided, the
+The :class:`~.SessionConfiguration` object allows you to provide a path to a custom CA certificate. If provided, the
 custom CA certificate is used to verify the service's TLS certificate instead of the ``certifi`` package.
-
-Advanced features
------------------
-You can set all options that are available in Python library *requests* through
-the client. This enables you to configure custom SSL certificate validation, send
-client certificates if your API server requires them, and configure many other options.
-
-For example, to send a client certificate with every request:
-
-.. code:: python
-
-   >>> from ansys.openapi.common import SessionConfiguration
-   >>> configuration = SessionConfiguration(
-   ...    client_cert_path='./my-client-cert.pem',
-   ...    client_cert_key='secret-key'
-   ... )
-   >>> client.configuration = configuration
-
-
-Platform-specific Kerberos configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Kerberos authentication should be supported wherever the MIT or Heimdal Kerberos client
-can be installed. OpenAPI-Common has been tested on the platforms that follow.
-If you manage to use it on another platform, consider contributing installation steps for
-your platform by making a pull request.
-
-Ubuntu 20.04
-^^^^^^^^^^^^
-
-Ubuntu requires the ``gssapi`` Python module to be built from source. This requires the
-Kerberos headers, Python headers for the version of Python that you are using, and a
-supported compiler. (GCC works well.)
-
-You should then be able to install this module with the ``[linux-kerberos]`` extra:
-
-.. code-block:: sh
-
-   sudo apt install build-essentials python3.8-dev libkrb5-dev
-   pip install ansys-openapi-common[linux-kerberos]
-
-
-Once the installation completes, ensure that your ``krb5.conf`` file is set up correctly
-for your Kerberos configuration and that you have a valid ``keytab`` file, which is
-normally in ``/etc/krb5.keytab``.

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -10,3 +10,4 @@ THIRDPARTY
 subclassed
 subclassing
 Intersphinx
+pip\-system\-certs

--- a/poetry.lock
+++ b/poetry.lock
@@ -1657,6 +1657,31 @@ code-style = ["pre-commit (==2.12.1)"]
 rtd = ["ipython", "myst-nb", "sphinx", "sphinx-book-theme", "sphinx-examples"]
 
 [[package]]
+name = "sphinx-design"
+version = "0.6.1"
+description = "A sphinx extension for designing beautiful, view size responsive web components."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "sphinx_design-0.6.1-py3-none-any.whl", hash = "sha256:b11f37db1a802a183d61b159d9a202314d4d2fe29c163437001324fe2f19549c"},
+    {file = "sphinx_design-0.6.1.tar.gz", hash = "sha256:b44eea3719386d04d765c1a8257caca2b3e6f8421d7b3a5e742c0fd45f84e632"},
+]
+
+[package.dependencies]
+sphinx = ">=6,<9"
+
+[package.extras]
+code-style = ["pre-commit (>=3,<4)"]
+rtd = ["myst-parser (>=2,<4)"]
+testing = ["defusedxml", "myst-parser (>=2,<4)", "pytest (>=8.3,<9.0)", "pytest-cov", "pytest-regressions"]
+testing-no-myst = ["defusedxml", "pytest (>=8.3,<9.0)", "pytest-cov", "pytest-regressions"]
+theme-furo = ["furo (>=2024.7.18,<2024.8.0)"]
+theme-im = ["sphinx-immaterial (>=0.12.2,<0.13.0)"]
+theme-pydata = ["pydata-sphinx-theme (>=0.15.2,<0.16.0)"]
+theme-rtd = ["sphinx-rtd-theme (>=2.0,<3.0)"]
+theme-sbt = ["sphinx-book-theme (>=1.1,<2.0)"]
+
+[[package]]
 name = "sphinx-notfound-page"
 version = "1.0.4"
 description = "Sphinx extension to build a 404 page with absolute URLs"
@@ -1947,4 +1972,4 @@ oidc = ["keyring", "requests_auth"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "5650d830317400fd2d9b6da8e43b7e4582a81bf8fe0cdd48a3e2e0983b10c1f3"
+content-hash = "1f5c61a798595d73b94f5784542385f9f5ba006bac24b4603f9042e15fefe9ee"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ types-requests = { version = "*" }
 types-python-dateutil = { version = "*" }
 requests_auth = { version = "*" }
 keyring = { version = "*" }
+sphinx-design = "^0.6.0"
 
 [tool.poetry.group.dev-linux]
 optional = true


### PR DESCRIPTION
Closes #705

This PR was originally going to just include the README in the HTML documentation, but I realize the HTML documentation differs significantly from the other PyAnsys documentation styles in terms of structure, so I took this opportunity to re-organize things.

The PyAnsys approach is to include minimal info in the README, limited mainly to installation and getting started. The docs now mirror that approach, and use a sphinx-design gallery to link to other locations. The content from the README has moved to a new User Guide document, which describes how to use openapi-common.