### PR TITLE
Relax validation on enum values deserialization 

### DIFF
--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -409,7 +409,6 @@ class ApiClient(ApiClientBase):
 
         klass = self.models[klass_name]
         if issubclass(klass, Enum):
-            assert isinstance(data, str)
             return klass(data)
         else:
             assert isinstance(data, (dict, str))

--- a/tests/models/example_int_enum.py
+++ b/tests/models/example_int_enum.py
@@ -20,8 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .example_base_model import ExampleBaseModel
-from .example_enum import ExampleEnum
-from .example_int_enum import ExampleIntEnum
-from .example_model import ExampleModel
-from .example_model_with_enum import ExampleModelWithEnum
+from enum import Enum
+
+
+class ExampleIntEnum(Enum):
+    _200 = 200
+    _404 = 404

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -401,6 +401,34 @@ class TestDeserialization:
         assert isinstance(serialized_enum, models.ExampleEnum)
         assert serialized_enum == models.ExampleEnum.GOOD
 
+    def test_deserialize_int_enum(self):
+        from . import models
+
+        self._client.setup_client(models)
+        value = 200
+        type_ref = "ExampleIntEnum"
+        serialized_enum = self._client._ApiClient__deserialize(value, type_ref)
+        assert isinstance(serialized_enum, models.ExampleIntEnum)
+        assert serialized_enum == models.ExampleIntEnum._200
+
+    @pytest.mark.parametrize(
+        ["value", "target_enum", "expected_error_msg"],
+        [
+            ("200", "ExampleIntEnum", "'200' is not a valid ExampleIntEnum"),
+            (4.5, "ExampleIntEnum", "4.5 is not a valid ExampleIntEnum"),
+            (4, "ExampleIntEnum", "4 is not a valid ExampleIntEnum"),
+            ("SomeValue", "ExampleEnum", "'SomeValue' is not a valid ExampleEnum"),
+            (4.5, "ExampleEnum", "4.5 is not a valid ExampleEnum"),
+            (4, "ExampleEnum", "4 is not a valid ExampleEnum"),
+        ]
+    )
+    def test_deserialize_enums_raises_helpful_message_on_wrong_value(self, value, target_enum, expected_error_msg):
+        from . import models
+
+        self._client.setup_client(models)
+        with pytest.raises(ValueError, match=expected_error_msg):
+            _ = self._client._ApiClient__deserialize(value, target_enum)
+
     @pytest.mark.parametrize(
         ("data", "target_type"),
         (


### PR DESCRIPTION
Relax validation on enum values deserialization to allow types other than strings.
This, in addition to https://github.com/ansys/openapi-client-template/pull/235, is to fix https://github.com/ansys/openapi-client-template/issues/234.

See previous PR #751 for discussion, especially https://github.com/ansys/openapi-common/pull/751#issuecomment-2741272694