### PR TITLE
Add token to GitHub release CI

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -172,6 +172,7 @@ jobs:
         name: "Release to GitHub"
         with:
           library-name: ${{ env.LIBRARY_NAME }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-deploy-stable:
     name: "Deploy stable documentation"

--- a/doc/changelog.d/761.maintenance.md
+++ b/doc/changelog.d/761.maintenance.md
@@ -1,0 +1,1 @@
+Add token to GitHub release CI


### PR DESCRIPTION
Fixes #760 

The documentation for the release-github action shows that the token parameter is required: https://actions.docs.ansys.com/version/stable/release-actions/index.html#release-github-action

We presumably missed this change to the action because we release from this repository relatively rarely.

Once this is merged, it should be cherry-picked onto the release/2.2 branch.