### PR TITLE
Revert to pypa/gh-action-pypi-publish for publishing

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -152,6 +152,7 @@ jobs:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           bot-email: ${{ secrets.PYANSYS_CI_BOT_EMAIL }}
+
   release:
     name: "Release"
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
@@ -162,17 +163,25 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: ansys/actions/release-pypi-public@v9
-        name: "Release to public PyPI"
-        with:
-          library-name: ${{ env.LIBRARY_NAME }}
-          use-trusted-publisher: true
+    - name: "Download the library artifacts from build-library step"
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+      with:
+        name: ${{ env.PACKAGE_NAME }}-artifacts
+        path: ${{ env.PACKAGE_NAME }}-artifacts
 
-      - uses: ansys/actions/release-github@v9
-        name: "Release to GitHub"
-        with:
-          library-name: ${{ env.LIBRARY_NAME }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+    - name: "Upload artifacts to PyPI using trusted publisher"
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      with:
+        repository-url: "https://upload.pypi.org/legacy/"
+        print-hash: true
+        packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
+        skip-existing: false
+
+    - uses: ansys/actions/release-github@v9
+      name: "Release to GitHub"
+      with:
+        library-name: ${{ env.LIBRARY_NAME }}
+        token: ${{ secrets.GITHUB_TOKEN }}
 
   doc-deploy-stable:
     name: "Deploy stable documentation"

--- a/doc/changelog.d/777.maintenance.md
+++ b/doc/changelog.d/777.maintenance.md
@@ -1,0 +1,1 @@
+Revert to pypa/gh-action-pypi-publish for publishing


### PR DESCRIPTION
Latest versions of the source action prevent it being used in reusable workflows, so ansys actions have removed support from their publish action. Replace this with the source action directly in our release job.