### PR TITLE
Fix release action environment variable

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -166,15 +166,15 @@ jobs:
     - name: "Download the library artifacts from build-library step"
       uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
       with:
-        name: ${{ env.PACKAGE_NAME }}-artifacts
-        path: ${{ env.PACKAGE_NAME }}-artifacts
+        name: ${{ env.LIBRARY_NAME }}-artifacts
+        path: ${{ env.LIBRARY_NAME }}-artifacts
 
     - name: "Upload artifacts to PyPI using trusted publisher"
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         repository-url: "https://upload.pypi.org/legacy/"
         print-hash: true
-        packages-dir: ${{ env.PACKAGE_NAME }}-artifacts
+        packages-dir: ${{ env.LIBRARY_NAME }}-artifacts
         skip-existing: false
 
     - uses: ansys/actions/release-github@v9

--- a/doc/changelog.d/781.maintenance.md
+++ b/doc/changelog.d/781.maintenance.md
@@ -1,0 +1,1 @@
+Fix release action environment variable


### PR DESCRIPTION
The env var for the package name is `LIBRARY_NAME` which is not the one in the pyansys migration guide. This made the attempted release of 2.3 fail.