### PR TITLE
Still raise ApiException if non-success response deserialization fails

### DIFF
--- a/doc/changelog.d/785.fixed.md
+++ b/doc/changelog.d/785.fixed.md
@@ -1,0 +1,1 @@
+Raise ApiException if error deserialization fails

--- a/doc/changelog.d/785.fixed.md
+++ b/doc/changelog.d/785.fixed.md
@@ -1,1 +1,1 @@
-Raise ApiException if error deserialization fails
+Still raise ApiException if non-success response deserialization fails

--- a/src/ansys/openapi/common/_exceptions.py
+++ b/src/ansys/openapi/common/_exceptions.py
@@ -76,7 +76,8 @@ class ApiException(Exception):
     Provides the exception to raise when the remote server returns an unsuccessful response.
 
     For more information about the failure, inspect ``.status_code`` and ``.reason_phrase``. If the
-    server defines a custom exception model, ``.exception_model`` contains the deserialized response.
+    server defines a custom exception model, ``.exception_model`` contains the deserialized response if the
+    deserialization was successful.
 
     Parameters
     ----------

--- a/tests/models/example_exception.py
+++ b/tests/models/example_exception.py
@@ -37,7 +37,7 @@ class ExampleException(ModelBase):
     """
     swagger_types = {
         "exception_text": "str",
-        "exception_code": "int",
+        "exception_code": "ExampleIntEnum",
         "stack_trace": "list[str]",
     }
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -874,7 +874,7 @@ class TestResponseHandling:
         expected_url = TEST_URL + resource_path
 
         exception_text = "Item not found"
-        exception_code = "four oh four"
+        exception_code = "404"  # A string, not an int
         stack_trace = [
             "Source lines",
             "101: if id_ not in items:",

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -825,7 +825,7 @@ class TestResponseHandling:
             headers={"Content-Type": "application/json"},
         )
 
-        with pytest.raises(ValueError) as e:
+        with pytest.raises(ValueError):
             _, _, _ = self._client.call_api(
                 resource_path, method, response_type_map=response_type_map
             )


### PR DESCRIPTION
Closes #784 

Wrap the deserialization of the response in try/except block which catches all possible deserialization errors. Only raise the exception if the original response was a success response code, otherwise ignore the exception.

Modify the existing test case to make use of an enum, and use this enum to validate the new behavior.