### PR TITLE
Use commit SHA to pin action versions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -21,8 +21,8 @@ jobs:
     name: "Code style"
     runs-on: windows-latest
     steps:
-     - uses: ansys/actions/code-style@v9
-       with:
+      - uses: ansys/actions/code-style@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
+        with:
          python-version: ${{ env.MAIN_PYTHON_VERSION }}
          skip-install: "false"
 
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PyAnsys documentation style checks
-        uses: ansys/actions/doc-style@v9
+        uses: ansys/actions/doc-style@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ignore-changelogd: true
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Run Ansys documentation building action"
-        uses: ansys/actions/doc-build@v9
+        uses: ansys/actions/doc-build@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           check-links: false
           sphinxopts: "-W --keep-going"
@@ -58,7 +58,7 @@ jobs:
            os: [ubuntu-latest, windows-latest]
            python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: ansys/actions/build-wheelhouse@v9
+      - uses: ansys/actions/build-wheelhouse@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           library-name: ${{ env.LIBRARY_NAME }}
           operating-system: ${{ matrix.os }}
@@ -94,7 +94,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
     - name: Configure host kerberos
       run: |
@@ -127,7 +127,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - uses: ansys/actions/build-library@v9
+      - uses: ansys/actions/build-library@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           library-name: ${{ env.LIBRARY_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
@@ -139,7 +139,7 @@ jobs:
     needs: [ build-library ]
     if: github.event_name == 'push' && !contains(github.ref, 'refs/tags')
     steps:
-      - uses: ansys/actions/doc-deploy-dev@v9
+      - uses: ansys/actions/doc-deploy-dev@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -155,7 +155,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: ansys/actions/doc-deploy-changelog@v9
+      - uses: ansys/actions/doc-deploy-changelog@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
@@ -185,7 +185,7 @@ jobs:
         packages-dir: ${{ env.LIBRARY_NAME }}-artifacts
         skip-existing: false
 
-    - uses: ansys/actions/release-github@v9
+    - uses: ansys/actions/release-github@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
       name: "Release to GitHub"
       with:
         library-name: ${{ env.LIBRARY_NAME }}
@@ -197,7 +197,7 @@ jobs:
     needs: release
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     steps:
-      - uses: ansys/actions/doc-deploy-stable@v9
+      - uses: ansys/actions/doc-deploy-stable@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot_approve.yml
+++ b/.github/workflows/dependabot_approve.yml
@@ -8,7 +8,7 @@ jobs:
     # Checking the author will prevent your Action run failing on non-Dependabot PRs
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Approve a PR if not already approved
         run: |
           gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -18,8 +18,8 @@ jobs:
     name: Syncer
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: micnncim/action-label-syncer@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: micnncim/action-label-syncer@3abd5ab72fda571e69fffd97bd4e0033dd5f495c  # v1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -33,7 +33,7 @@ jobs:
     steps:
 
     - name: Label based on changed files and branch name
-      uses: actions/labeler@v5
+      uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  #v5.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Suggest to add labels
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043  #v4.0.0
       # Execute only when no labels have been applied to the pull request
       if: toJSON(github.event.pull_request.labels.*.name) == '{}'
       with:
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !startsWith( github.event.pull_request.head.ref, 'dependabot/') && !(startsWith(github.event.pull_request.head.ref, 'pre-commit-ci-update-config')) }}
     steps:
-    - uses: ansys/actions/doc-changelog@v9
+    - uses: ansys/actions/doc-changelog@2cf9a9c43235a000d613c2b13e64c954232a4553  # v9.0.9
       with:
         token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
         bot-user: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}

--- a/doc/changelog.d/795.maintenance.md
+++ b/doc/changelog.d/795.maintenance.md
@@ -1,0 +1,1 @@
+Use commit SHA

--- a/doc/changelog.d/795.maintenance.md
+++ b/doc/changelog.d/795.maintenance.md
@@ -1,1 +1,1 @@
-Use commit SHA
+Use commit SHA to pin action versions


### PR DESCRIPTION
Closes #794 

All actions are pinned to the latest available version, except for ansys/actions which are pinned to v9.0.9. See https://github.com/ansys/actions/issues/814 for cause.