### PR TITLE
Set more restrictive workflow permissions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -16,6 +16,9 @@ env:
   LIBRARY_NAME: 'ansys-openapi-common'
   DOCUMENTATION_CNAME: 'openapi.docs.pyansys.com'
 
+permissions:
+  contents: read
+
 jobs:
   code-style:
     name: "Code style"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -72,6 +72,9 @@ jobs:
     name: Unit test on supported platforms
     runs-on: ubuntu-latest
     needs: build-wheelhouse
+    permissions:
+      contents: read
+      packages: read
     services:
       # Label used to access the service container
       kdc-server:

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - '../labels.yml'
 
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/doc/changelog.d/801.maintenance.md
+++ b/doc/changelog.d/801.maintenance.md
@@ -1,0 +1,1 @@
+Set more restrictive workflow permissions


### PR DESCRIPTION
We have a number of security warnings around the default GITHUB_TOKEN permissions in this repository's CI. This PR sets a more restrictive set of permissions, which can then be extended as required for individual jobs.