### PR TITLE
Bump version to v2.4.0.dev0

### DIFF
--- a/doc/changelog.d/834.miscellaneous.md
+++ b/doc/changelog.d/834.miscellaneous.md
@@ -1,0 +1,1 @@
+Bump version to v2.4.0.dev0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "ansys-openapi-common"
 description = "Provides a helper to create sessions for use with Ansys OpenAPI clients."
-version = "2.4.0"
+version = "2.4.0.dev0"
 license = "MIT"
 authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
 maintainers = ["ANSYS, Inc. <pyansys.core@ansys.com>"]


### PR DESCRIPTION
We currently don't have a dev suffix on the version number on main. This may be causing issues with the docs, where the `dev` option doesn't seem to be updating correctly.