### PR TITLE
Add write permissions for documentation publish jobs

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -144,6 +144,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ build-library ]
     if: github.event_name == 'push' && !contains(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     steps:
       - uses: ansys/actions/doc-deploy-dev@8d3e4946f36c2a7d447b92e34b1022a5c9dc77a7  # v10.0.12
         with:
@@ -202,6 +204,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    permissions:
+      contents: write
     steps:
       - uses: ansys/actions/doc-deploy-stable@8d3e4946f36c2a7d447b92e34b1022a5c9dc77a7  # v10.0.12
         with:

--- a/doc/changelog.d/835.miscellaneous.md
+++ b/doc/changelog.d/835.miscellaneous.md
@@ -1,0 +1,1 @@
+Add write permissions for documentation publish jobs


### PR DESCRIPTION
Documentation publishing is currently broken. I believe this is because we switched to using read permissions globally.

The documentation publishing jobs require write permissions to push the latest docs to the github-pages branch.