### PR TITLE
Add workflow to check dependencies and action security

### DIFF
--- a/.github/workflows/security_checks.yml
+++ b/.github/workflows/security_checks.yml
@@ -1,0 +1,34 @@
+name: night
+
+on:
+  schedule:
+    - cron: '0 0 * * TUE'
+  workflow_dispatch:
+
+env:
+  MAIN_PYTHON_VERSION: '3.12'
+  LIBRARY_NAME: 'ansys-openapi-common'
+
+permissions: {}
+
+jobs:
+  actions-security:
+    name: "Check actions security"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ansys/actions/check-actions-security@v10.1
+        with:
+          generate-summary: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          auditing-level: 'high'
+          trust-ansys-actions: true
+  
+  check-vulnerabilities:
+    name: "Check library vulnerabilities"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ansys/actions/check-vulnerabilities@v10.1
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          python-package-name: ${{ env.LIBRARY_NAME }}

--- a/.github/workflows/security_checks.yml
+++ b/.github/workflows/security_checks.yml
@@ -22,7 +22,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           auditing-level: 'high'
           trust-ansys-actions: true
-  
+
   check-vulnerabilities:
     name: "Check library vulnerabilities"
     runs-on: ubuntu-latest

--- a/.github/workflows/security_checks.yml
+++ b/.github/workflows/security_checks.yml
@@ -16,7 +16,7 @@ jobs:
     name: "Check actions security"
     runs-on: ubuntu-latest
     steps:
-      - uses: ansys/actions/check-actions-security@v10.1
+      - uses: ansys/actions/check-actions-security@c2fa7c93f6883114e0e643599431b33d29f0b13f # v10.1.4
         with:
           generate-summary: true
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -27,7 +27,7 @@ jobs:
     name: "Check library vulnerabilities"
     runs-on: ubuntu-latest
     steps:
-      - uses: ansys/actions/check-vulnerabilities@v10.1
+      - uses: ansys/actions/check-vulnerabilities@c2fa7c93f6883114e0e643599431b33d29f0b13f # v10.1.4
         with:
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
           token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}

--- a/doc/changelog.d/888.miscellaneous.md
+++ b/doc/changelog.d/888.miscellaneous.md
@@ -1,0 +1,1 @@
+Add workflow to check dependencies and action security


### PR DESCRIPTION
Closes #883 
Closes #824 

Add a weekly workflow to check package vulnerabilities and to audit third-party actions.