### PR TITLE
Fix tests when run with pytest 9.1

### DIFF
--- a/doc/changelog.d/1086.fixed.md
+++ b/doc/changelog.d/1086.fixed.md
@@ -1,0 +1,1 @@
+Fix tests when run with pytest 9.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,13 +137,13 @@ title_format = "`{version} <https://github.com/ansys/openapi-common/releases/tag
 issue_format = "`#{issue} <https://github.com/ansys/openapi-common/pull/{issue}>`_"
 
 [[tool.towncrier.type]]
-directory = "added"
-name = "Added"
+directory = "breaking"
+name = "Breaking"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "changed"
-name = "Changed"
+directory = "added"
+name = "Added"
 showcontent = true
 
 [[tool.towncrier.type]]
@@ -152,18 +152,13 @@ name = "Fixed"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "dependencies"
-name = "Dependencies"
-showcontent = true
-
-[[tool.towncrier.type]]
-directory = "miscellaneous"
-name = "Miscellaneous"
-showcontent = true
-
-[[tool.towncrier.type]]
 directory = "documentation"
 name = "Documentation"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "dependencies"
+name = "Dependencies"
 showcontent = true
 
 [[tool.towncrier.type]]
@@ -172,6 +167,17 @@ name = "Maintenance"
 showcontent = true
 
 [[tool.towncrier.type]]
+directory = "miscellaneous"
+name = "Miscellaneous"
+showcontent = true
+
+[[tool.towncrier.type]]
 directory = "test"
 name = "Test"
 showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -742,7 +742,7 @@ class TestRequestDispatch:
         self._transport = requests.Session()
         self._client = ApiClient(self._transport, TEST_URL, SessionConfiguration())
 
-    @pytest.mark.parametrize(("verb", "method_call"), (zip(verbs, method_names)))
+    @pytest.mark.parametrize(("verb", "method_call"), list(zip(verbs, method_names)))
     def test_request_dispatch(self, mocker, verb, method_call):
         # TODO: Can we move the logic deciding which parameters must be provided into the test, rather than the
         #  function above?

--- a/tests/test_parse_authenticate.py
+++ b/tests/test_parse_authenticate.py
@@ -70,7 +70,7 @@ def test_negotiate_with_token(test_input, expected):
     assert obtained == CaseInsensitiveOrderedDict(expected)
 
 
-@pytest.mark.parametrize("test_input, expected", zip(test_challenges, test_outcomes))
+@pytest.mark.parametrize("test_input, expected", list(zip(test_challenges, test_outcomes)))
 def test_multiple_challenges(test_input, expected):
     obtained = parse_authenticate(test_input)
     assert obtained == expected

--- a/uv.lock
+++ b/uv.lock
@@ -1411,7 +1411,7 @@ kerberos = [
 
 [[package]]
 name = "pytest"
-version = "9.0.3"
+version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1422,9 +1422,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
pytest 9.1 requires all parameters to be provided as collection iterables. Iterators, like those returned by zip, raise a warning, which we treat as an error.

This PR bumps pytest to 9.1.1 and wraps a use of `zip()` in `list()`.