### PR TITLE
Add upfront OIDC provider configuration via with_oidc()

### DIFF
--- a/doc/changelog.d/1087.added.md
+++ b/doc/changelog.d/1087.added.md
@@ -1,0 +1,1 @@
+Add upfront OIDC provider configuration via with_oidc()

--- a/doc/changelog.d/added/oidc-upfront-configuration.md
+++ b/doc/changelog.d/added/oidc-upfront-configuration.md
@@ -1,0 +1,1 @@
+Add upfront OIDC configuration via the `oidc_configuration` argument to `ApiClientFactory.with_oidc()`.

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -17,6 +17,7 @@ classes.
    ApiClientFactory
    AuthenticationScheme
    OIDCSessionBuilder
+   OIDCConfiguration
    SessionConfiguration
 
 

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -41,6 +41,38 @@ file on your system.
 Windows and Linux users can authenticate with OIDC-enabled APIs by using the ``[oidc]`` extra.
 Currently only the Authorization Code authentication flow is supported.
 
+For identity providers such as Azure AD B2C that do not advertise OIDC settings in a
+``401`` response, provide an :class:`~.OIDCConfiguration` to
+:meth:`~ansys.openapi.common.ApiClientFactory.with_oidc`:
+
+.. code:: python
+
+   from ansys.openapi.common import ApiClientFactory, OIDCConfiguration
+
+   client = (
+       ApiClientFactory("https://my-api.com/v1.svc")
+       .with_oidc(
+           oidc_configuration=OIDCConfiguration(
+               client_id="your-app-client-id",
+               well_known_url=(
+                   "https://contoso.b2clogin.com/contoso.onmicrosoft.com/"
+                   "b2c_1_susi/v2.0/.well-known/openid-configuration"
+               ),
+               scopes=[
+                   "openid",
+                   "offline_access",
+                   "https://contoso.onmicrosoft.com/your-api-id/access_as_user",
+               ],
+               redirect_uri_port=32284,
+           )
+       )
+       .authorize()
+       .connect()
+   )
+
+When ``oidc_configuration`` is provided, ``with_oidc()`` does not contact the API to
+discover authentication settings.
+
 .. list-table:: Authentication methods by platform
    :header-rows: 1
    :widths: 30 15 15 40

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -43,7 +43,7 @@ Currently only the Authorization Code authentication flow is supported.
 
 For identity providers such as Azure AD B2C that do not advertise OIDC settings in a
 ``401`` response, provide an :class:`~.OIDCConfiguration` to
-:meth:`~ansys.openapi.common.ApiClientFactory.with_oidc`:
+:meth:`~.ApiClientFactory.with_oidc`:
 
 .. code:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ doc = [
     "sphinx-notfound-page==1.1.0",
     "sphinx-copybutton==0.5.2",
     "sphinx-design==0.6.1",
+    "requests_auth>=8.0.0,<9.0.0",
+    "keyring>=22,<26",
 ]
 dev-linux = [
     "asgi_gssapi; sys_platform == 'linux'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,9 @@ filterwarnings = [
 ]
 xfail_strict = true
 
+[tool.bandit.assert_used]
+skips = ["*_test.py", "*test_*.py", "tests/*", "./tests/*"]
+
 [tool.pydocstyle]
 convention = "numpy"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,8 +68,6 @@ doc = [
     "sphinx-notfound-page==1.1.0",
     "sphinx-copybutton==0.5.2",
     "sphinx-design==0.6.1",
-    "requests_auth>=8.0.0,<9.0.0",
-    "keyring>=22,<26",
 ]
 dev-linux = [
     "asgi_gssapi; sys_platform == 'linux'"

--- a/src/ansys/openapi/common/__init__.py
+++ b/src/ansys/openapi/common/__init__.py
@@ -34,13 +34,8 @@ from ._exceptions import (
     AuthenticationWarning,
     UndefinedObjectWarning,
 )
+from ._oidc_config import OIDCConfiguration
 from ._session import ApiClientFactory, AuthenticationScheme, OIDCSessionBuilder
-
-try:
-    from ._oidc import OIDCConfiguration
-except ImportError:
-    OIDCConfiguration = None  # type: ignore[misc, assignment]
-
 from ._util import SessionConfiguration, generate_user_agent
 
 __all__ = [

--- a/src/ansys/openapi/common/__init__.py
+++ b/src/ansys/openapi/common/__init__.py
@@ -35,6 +35,12 @@ from ._exceptions import (
     UndefinedObjectWarning,
 )
 from ._session import ApiClientFactory, AuthenticationScheme, OIDCSessionBuilder
+
+try:
+    from ._oidc import OIDCConfiguration
+except ImportError:
+    OIDCConfiguration = None  # type: ignore[misc, assignment]
+
 from ._util import SessionConfiguration, generate_user_agent
 
 __all__ = [
@@ -47,6 +53,7 @@ __all__ = [
     "AuthenticationWarning",
     "generate_user_agent",
     "OIDCSessionBuilder",
+    "OIDCConfiguration",
     "ApiBase",
     "ApiClientBase",
     "ModelBase",

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -19,7 +19,6 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 import urllib.parse
 
@@ -33,6 +32,7 @@ from requests_auth import (  # type: ignore[import-untyped, unused-ignore]
 )
 
 from ._logger import logger
+from ._oidc_config import OIDCConfiguration
 from ._util import (
     RequestsConfiguration,
     SessionConfiguration,
@@ -46,71 +46,6 @@ _ENDPOINT_CONFIGURATION_ERROR = (
     "OIDC configuration must include client_id and either well_known_url or both "
     "authorization_endpoint and token_endpoint."
 )
-
-
-@dataclass
-class OIDCConfiguration:
-    """OpenID Connect settings for API authentication.
-
-    When provided on :meth:`~ansys.openapi.common.ApiClientFactory.with_oidc`, the OIDC
-    session is configured without contacting the API for a ``401`` response.
-
-    Parameters
-    ----------
-    client_id : str, optional
-        OAuth client identifier. Maps from the ``clientid`` ``WWW-Authenticate`` parameter.
-    authority : str, optional
-        Identity provider authority URL from a ``401`` response. Used only for legacy
-        API-driven discovery when ``well_known_url`` and explicit endpoints are not set.
-    authorization_endpoint : str, optional
-        Authorization endpoint URL. When set together with ``token_endpoint``,
-        the well-known endpoint is not contacted.
-    token_endpoint : str, optional
-        Token endpoint URL.
-    well_known_url : str, optional
-        OpenID Provider metadata URL. When provided without explicit endpoints,
-        ``authorization_endpoint`` and ``token_endpoint`` are fetched from this URL.
-    scopes : list[str], optional
-        OAuth scopes to request. Maps from the ``scope`` ``WWW-Authenticate`` parameter.
-    api_audience : str, optional
-        API audience for Auth0-style providers. Maps from the ``apiAudience``
-        ``WWW-Authenticate`` parameter. Omit for Azure AD B2C.
-    redirect_uri : str, optional
-        Registered redirect URI for the interactive login flow. Maps from the
-        ``redirecturi`` ``WWW-Authenticate`` parameter.
-    redirect_uri_port : int, optional
-        Local port used for the browser redirect when ``redirect_uri`` is not set.
-        The default is ``32284``.
-    """
-
-    client_id: Optional[str] = None
-    authority: Optional[str] = None
-    authorization_endpoint: Optional[str] = None
-    token_endpoint: Optional[str] = None
-    well_known_url: Optional[str] = None
-    scopes: Optional[List[str]] = None
-    api_audience: Optional[str] = None
-    redirect_uri: Optional[str] = None
-    redirect_uri_port: int = 32284
-
-    def is_complete(self) -> bool:
-        """Return whether enough configuration is present to skip ``401`` discovery."""
-        if not self.client_id:
-            return False
-        if self.authorization_endpoint and self.token_endpoint:
-            return True
-        return bool(self.well_known_url)
-
-    def has_explicit_endpoints(self) -> bool:
-        """Return whether both OAuth endpoints were provided directly."""
-        return bool(self.authorization_endpoint and self.token_endpoint)
-
-    def has_partial_endpoints(self) -> bool:
-        """Return whether only one OAuth endpoint was provided."""
-        return (
-            bool(self.authorization_endpoint or self.token_endpoint)
-            and not self.has_explicit_endpoints()
-        )
 
 
 class OIDCSessionFactory:

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -51,8 +51,9 @@ _ENDPOINT_CONFIGURATION_ERROR = (
 class OIDCSessionFactory:
     """Builds authenticated API sessions from OpenID Connect configuration.
 
-    Use :meth:`from_unauthorized_response` when parameters are discovered from a
-    ``401`` response, or :meth:`from_configuration` when settings are provided upfront.
+    Construct directly with an :class:`~ansys.openapi.common.OIDCConfiguration`, or use
+    :meth:`from_unauthorized_response` when parameters are discovered from a ``401``
+    response, or :meth:`from_configuration` when settings are provided upfront.
 
     Once constructed, the factory can supply a session using a stored token, a provided
     refresh token, an access token, or an interactive browser login.
@@ -72,9 +73,8 @@ class OIDCSessionFactory:
     _authorized_session: requests.Session
     _auth: OAuth2AuthorizationCodePKCE
 
-    @classmethod
-    def _from_parsed_config(
-        cls,
+    def __init__(
+        self,
         api_url: str,
         oidc_config: OIDCConfiguration,
         initial_session: requests.Session,
@@ -82,17 +82,49 @@ class OIDCSessionFactory:
         idp_session_configuration: Optional[SessionConfiguration] = None,
         *,
         default_scopes: bool = False,
-    ) -> "OIDCSessionFactory":
-        factory = cls.__new__(cls)
-        factory._api_url = api_url
-        factory._oidc_config = oidc_config
-        factory._initialize_sessions(
+    ) -> None:
+        """Create a factory from OpenID Connect configuration.
+
+        Parameters
+        ----------
+        api_url : str
+            Base URL of the API server.
+        oidc_config : OIDCConfiguration
+            OpenID Connect provider settings.
+        initial_session : requests.Session
+            Session to use while negotiating with the identity provider.
+        api_session_configuration : SessionConfiguration, optional
+            Configuration settings for connections to the API server.
+        idp_session_configuration : SessionConfiguration, optional
+            Configuration settings for connections to the OpenID identity provider.
+        default_scopes : bool, optional
+            When ``True`` and ``oidc_config.scopes`` is unset, request ``openid`` and
+            ``offline_access``. The default is ``False``.
+        """
+        if not oidc_config.client_id:
+            raise ValueError("OIDC configuration must include client_id.")
+
+        if oidc_config.has_partial_endpoints():
+            raise ValueError(
+                "OIDC configuration must include both authorization_endpoint and "
+                "token_endpoint when either is provided."
+            )
+
+        if (
+            not oidc_config.has_explicit_endpoints()
+            and not oidc_config.well_known_url
+            and not oidc_config.authority
+        ):
+            raise ValueError(_ENDPOINT_CONFIGURATION_ERROR)
+
+        self._api_url = api_url
+        self._oidc_config = oidc_config
+        self._initialize_sessions(
             initial_session,
             api_session_configuration,
             idp_session_configuration,
         )
-        factory._configure_oauth(default_scopes=default_scopes)
-        return factory
+        self._configure_oauth(default_scopes=default_scopes)
 
     @classmethod
     def from_unauthorized_response(
@@ -120,7 +152,7 @@ class OIDCSessionFactory:
 
         bearer_parameters = cls._parse_unauthorized_header(initial_response)
         oidc_config = cls._oidc_config_from_bearer(bearer_parameters)
-        return cls._from_parsed_config(
+        return cls(
             initial_response.url,
             oidc_config,
             initial_session,
@@ -152,15 +184,6 @@ class OIDCSessionFactory:
         idp_session_configuration : SessionConfiguration, optional
             Configuration settings for connections to the OpenID identity provider.
         """
-        if not oidc_configuration.client_id:
-            raise ValueError("OIDC configuration must include client_id.")
-
-        if oidc_configuration.has_partial_endpoints():
-            raise ValueError(
-                "OIDC configuration must include both authorization_endpoint and "
-                "token_endpoint when either is provided."
-            )
-
         if (
             not oidc_configuration.has_explicit_endpoints()
             and not oidc_configuration.well_known_url
@@ -169,7 +192,7 @@ class OIDCSessionFactory:
 
         logger.debug("Creating OIDC session handler from provided configuration...")
 
-        return cls._from_parsed_config(
+        return cls(
             api_url,
             oidc_configuration,
             initial_session,

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -19,8 +19,8 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-from typing import Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
 import urllib.parse
 
 import keyring
@@ -40,9 +40,77 @@ from ._util import (
     set_session_kwargs,
 )
 
-TYPE_CHECKING = False
-if TYPE_CHECKING:
-    from . import SessionConfiguration
+_DEFAULT_SCOPES = ["openid", "offline_access"]
+
+_ENDPOINT_CONFIGURATION_ERROR = (
+    "OIDC configuration must include client_id and either well_known_url or both "
+    "authorization_endpoint and token_endpoint."
+)
+
+
+@dataclass
+class OIDCConfiguration:
+    """OpenID Connect settings for API authentication.
+
+    When provided on :meth:`~ansys.openapi.common.ApiClientFactory.with_oidc`, the OIDC
+    session is configured without contacting the API for a ``401`` response.
+
+    Parameters
+    ----------
+    client_id : str, optional
+        OAuth client identifier. Maps from the ``clientid`` ``WWW-Authenticate`` parameter.
+    authority : str, optional
+        Identity provider authority URL from a ``401`` response. Used only for legacy
+        API-driven discovery when ``well_known_url`` and explicit endpoints are not set.
+    authorization_endpoint : str, optional
+        Authorization endpoint URL. When set together with ``token_endpoint``,
+        the well-known endpoint is not contacted.
+    token_endpoint : str, optional
+        Token endpoint URL.
+    well_known_url : str, optional
+        OpenID Provider metadata URL. When provided without explicit endpoints,
+        ``authorization_endpoint`` and ``token_endpoint`` are fetched from this URL.
+    scopes : list[str], optional
+        OAuth scopes to request. Maps from the ``scope`` ``WWW-Authenticate`` parameter.
+    api_audience : str, optional
+        API audience for Auth0-style providers. Maps from the ``apiAudience``
+        ``WWW-Authenticate`` parameter. Omit for Azure AD B2C.
+    redirect_uri : str, optional
+        Registered redirect URI for the interactive login flow. Maps from the
+        ``redirecturi`` ``WWW-Authenticate`` parameter.
+    redirect_uri_port : int, optional
+        Local port used for the browser redirect when ``redirect_uri`` is not set.
+        The default is ``32284``.
+    """
+
+    client_id: Optional[str] = None
+    authority: Optional[str] = None
+    authorization_endpoint: Optional[str] = None
+    token_endpoint: Optional[str] = None
+    well_known_url: Optional[str] = None
+    scopes: Optional[List[str]] = None
+    api_audience: Optional[str] = None
+    redirect_uri: Optional[str] = None
+    redirect_uri_port: int = 32284
+
+    def is_complete(self) -> bool:
+        """Return whether enough configuration is present to skip ``401`` discovery."""
+        if not self.client_id:
+            return False
+        if self.authorization_endpoint and self.token_endpoint:
+            return True
+        return bool(self.well_known_url)
+
+    def has_explicit_endpoints(self) -> bool:
+        """Return whether both OAuth endpoints were provided directly."""
+        return bool(self.authorization_endpoint and self.token_endpoint)
+
+    def has_partial_endpoints(self) -> bool:
+        """Return whether only one OAuth endpoint was provided."""
+        return (
+            bool(self.authorization_endpoint or self.token_endpoint)
+            and not self.has_explicit_endpoints()
+        )
 
 
 class OIDCSessionFactory:
@@ -69,6 +137,14 @@ class OIDCSessionFactory:
     ``Content-Type`` headers will be overridden. Other settings are respected.
     """
 
+    _api_url: str
+    _oidc_config: OIDCConfiguration
+    _api_session_configuration: RequestsConfiguration
+    _idp_session_configuration: RequestsConfiguration
+    _oauth_requests_session: requests.Session
+    _authorized_session: requests.Session
+    _auth: OAuth2AuthorizationCodePKCE
+
     def __init__(
         self,
         initial_session: requests.Session,
@@ -76,12 +152,84 @@ class OIDCSessionFactory:
         api_session_configuration: Optional[SessionConfiguration] = None,
         idp_session_configuration: Optional[SessionConfiguration] = None,
     ) -> None:
-        self._api_url = initial_response.url
+        configured = OIDCSessionFactory.from_unauthorized_response(
+            initial_session,
+            initial_response,
+            api_session_configuration,
+            idp_session_configuration,
+        )
+        self.__dict__.update(configured.__dict__)
 
-        logger.debug("Creating OIDC session handler...")
+    @classmethod
+    def from_unauthorized_response(
+        cls,
+        initial_session: requests.Session,
+        initial_response: requests.Response,
+        api_session_configuration: Optional[SessionConfiguration] = None,
+        idp_session_configuration: Optional[SessionConfiguration] = None,
+    ) -> "OIDCSessionFactory":
+        """Create a factory using parameters from the API ``401`` response."""
+        factory = cls.__new__(cls)
+        factory._api_url = initial_response.url
 
-        self._authenticate_parameters = self._parse_unauthorized_header(initial_response)
+        logger.debug("Creating OIDC session handler from unauthorized response...")
 
+        bearer_parameters = cls._parse_unauthorized_header(initial_response)
+        factory._oidc_config = cls._oidc_config_from_bearer(bearer_parameters)
+
+        factory._initialize_sessions(
+            initial_session,
+            api_session_configuration,
+            idp_session_configuration,
+        )
+        factory._configure_oauth()
+        return factory
+
+    @classmethod
+    def from_configuration(
+        cls,
+        api_url: str,
+        oidc_configuration: OIDCConfiguration,
+        initial_session: requests.Session,
+        api_session_configuration: Optional[SessionConfiguration] = None,
+        idp_session_configuration: Optional[SessionConfiguration] = None,
+    ) -> "OIDCSessionFactory":
+        """Create a factory using upfront OpenID Connect configuration."""
+        if not oidc_configuration.client_id:
+            raise ValueError("OIDC configuration must include client_id.")
+
+        if oidc_configuration.has_partial_endpoints():
+            raise ValueError(
+                "OIDC configuration must include both authorization_endpoint and "
+                "token_endpoint when either is provided."
+            )
+
+        if (
+            not oidc_configuration.has_explicit_endpoints()
+            and not oidc_configuration.well_known_url
+        ):
+            raise ValueError(_ENDPOINT_CONFIGURATION_ERROR)
+
+        factory = cls.__new__(cls)
+        factory._api_url = api_url
+        factory._oidc_config = oidc_configuration
+
+        logger.debug("Creating OIDC session handler from provided configuration...")
+
+        factory._initialize_sessions(
+            initial_session,
+            api_session_configuration,
+            idp_session_configuration,
+        )
+        factory._configure_oauth(default_scopes=True)
+        return factory
+
+    def _initialize_sessions(
+        self,
+        initial_session: requests.Session,
+        api_session_configuration: Optional[SessionConfiguration],
+        idp_session_configuration: Optional[SessionConfiguration],
+    ) -> None:
         if api_session_configuration is None:
             api_session_configuration = SessionConfiguration()
         if idp_session_configuration is None:
@@ -95,31 +243,26 @@ class OIDCSessionFactory:
         self._oauth_requests_session = initial_session
         set_session_kwargs(self._oauth_requests_session, self._idp_session_configuration)
 
-        self._well_known_parameters = self._fetch_and_parse_well_known(
-            self._authenticate_parameters["authority"]
-        )
+        self._authorized_session = requests.Session()
+        set_session_kwargs(self._authorized_session, self._api_session_configuration)
 
+    def _configure_oauth(self, default_scopes: bool = False) -> None:
         self._add_api_audience_if_set()
+        well_known_parameters = self._resolve_oauth_endpoints()
 
         logger.info("Configuring session...")
-        scopes = (
-            self._authenticate_parameters["scope"]
-            if "scope" in self._authenticate_parameters
-            else []
-        )
+        scopes = self._normalized_scopes(self._oidc_config.scopes, default_scopes=default_scopes)
+        oauth_kwargs = self._redirect_uri_kwargs(self._oidc_config)
+        if self._oidc_config.api_audience is not None:
+            oauth_kwargs["audience"] = self._oidc_config.api_audience
+        oauth_kwargs["client_id"] = self._oidc_config.client_id
+        oauth_kwargs["scope"] = scopes
+        oauth_kwargs["session"] = self._oauth_requests_session
 
         self._auth = OAuth2AuthorizationCodePKCE(
-            authorization_url=self._well_known_parameters["authorization_endpoint"],
-            token_url=self._well_known_parameters["token_endpoint"],
-            redirect_uri_port=32284,
-            audience=(
-                self._authenticate_parameters["apiAudience"]
-                if "apiAudience" in self._authenticate_parameters
-                else None
-            ),
-            client_id=self._authenticate_parameters["clientid"],
-            scope=scopes,
-            session=self._oauth_requests_session,
+            authorization_url=well_known_parameters["authorization_endpoint"],
+            token_url=well_known_parameters["token_endpoint"],
+            **oauth_kwargs,
         )
 
         # If using Auth0 we cannot provide an audience with requests
@@ -128,8 +271,6 @@ class OIDCSessionFactory:
         # required to access the user_info endpoint.
         self._auth.refresh_data.pop("audience", None)
 
-        self._authorized_session = requests.Session()
-        set_session_kwargs(self._authorized_session, self._api_session_configuration)
         logger.info("Configuration complete.")
 
     def get_session_with_access_token(self, access_token: str) -> requests.Session:
@@ -220,6 +361,48 @@ class OIDCSessionFactory:
         return self._authorized_session
 
     @staticmethod
+    def _oidc_config_from_bearer(bearer_parameters: CaseInsensitiveDict) -> OIDCConfiguration:
+        scopes: Optional[List[str]] = None
+        if "scope" in bearer_parameters:
+            scope_value = bearer_parameters["scope"]
+            if isinstance(scope_value, str):
+                scopes = scope_value.split()
+            elif isinstance(scope_value, list):
+                scopes = scope_value
+
+        return OIDCConfiguration(
+            client_id=bearer_parameters["clientid"],
+            authority=bearer_parameters["authority"],
+            redirect_uri=bearer_parameters.get("redirecturi"),
+            scopes=scopes,
+            api_audience=bearer_parameters.get("apiAudience"),
+        )
+
+    @staticmethod
+    def _normalized_scopes(
+        scopes: Optional[List[str]], *, default_scopes: bool = False
+    ) -> Union[str, List[str]]:
+        if scopes is None:
+            if default_scopes:
+                return " ".join(_DEFAULT_SCOPES)
+            return []
+        return " ".join(scopes)
+
+    @staticmethod
+    def _redirect_uri_kwargs(oidc_config: OIDCConfiguration) -> Dict[str, Any]:
+        if oidc_config.redirect_uri:
+            parsed = urllib.parse.urlparse(oidc_config.redirect_uri)
+            if parsed.hostname:
+                endpoint = parsed.path.lstrip("/")
+                default_port = 443 if parsed.scheme == "https" else 80
+                return {
+                    "redirect_uri_domain": parsed.hostname,
+                    "redirect_uri_port": parsed.port or default_port,
+                    "redirect_uri_endpoint": endpoint,
+                }
+        return {"redirect_uri_port": oidc_config.redirect_uri_port}
+
+    @staticmethod
     def _parse_unauthorized_header(
         unauthorized_response: "requests.Response",
     ) -> "CaseInsensitiveDict":
@@ -273,21 +456,43 @@ class OIDCSessionFactory:
         else:
             return bearer_parameters
 
-    def _fetch_and_parse_well_known(self, url: str) -> CaseInsensitiveDict:
-        """Fetch and process the required parameters from identity provider's the well-known endpoint.
+    def _resolve_oauth_endpoints(self) -> CaseInsensitiveDict:
+        if self._oidc_config.has_partial_endpoints():
+            raise ValueError(
+                "OIDC configuration must include both authorization_endpoint and "
+                "token_endpoint when either is provided."
+            )
 
-        Perform a GET request to the endpoint and verify that the required parameters are returned.
+        if self._oidc_config.has_explicit_endpoints():
+            return CaseInsensitiveDict(
+                {
+                    "authorization_endpoint": self._oidc_config.authorization_endpoint,
+                    "token_endpoint": self._oidc_config.token_endpoint,
+                }
+            )
+
+        if self._oidc_config.well_known_url:
+            return self._fetch_and_parse_well_known(self._oidc_config.well_known_url)
+
+        if self._oidc_config.authority:
+            authority = self._oidc_config.authority
+            if not authority.endswith("/"):
+                authority += "/"
+            well_known_url = urllib.parse.urljoin(authority, ".well-known/openid-configuration")
+            return self._fetch_and_parse_well_known(well_known_url)
+
+        raise ValueError(_ENDPOINT_CONFIGURATION_ERROR)
+
+    def _fetch_and_parse_well_known(self, well_known_url: str) -> CaseInsensitiveDict:
+        """Fetch and process the required parameters from the well-known endpoint.
 
         Parameters
         ----------
-        url : str
-            URL referencing the OpenID identity provider's well-known endpoint.
+        well_known_url : str
+            OpenID Provider metadata URL.
         """
-        logger.info(f"Fetching configuration information from Identity Provider {url}")
-        if not url.endswith("/"):
-            url += "/"
-        well_known_endpoint = urllib.parse.urljoin(url, ".well-known/openid-configuration")
-        authority_response = self._oauth_requests_session.get(well_known_endpoint)
+        logger.info(f"Fetching configuration information from {well_known_url}")
+        authority_response = self._oauth_requests_session.get(well_known_url)
 
         logger.debug("Received configuration:")
         oidc_configuration = CaseInsensitiveDict(authority_response.json())  # type: CaseInsensitiveDict
@@ -340,9 +545,9 @@ class OIDCSessionFactory:
 
         Only add if provided by the OpenID identity provider. This is mainly required for Auth0.
         """
-        if "apiAudience" not in self._authenticate_parameters:
+        if self._oidc_config.api_audience is None:
             return
         mi_headers: CaseInsensitiveDict = self._api_session_configuration["headers"]
-        mi_headers["audience"] = self._authenticate_parameters["apiAudience"]
+        mi_headers["audience"] = self._oidc_config.api_audience
         idp_headers: CaseInsensitiveDict = self._idp_session_configuration["headers"]
-        idp_headers["audience"] = self._authenticate_parameters["apiAudience"]
+        idp_headers["audience"] = self._oidc_config.api_audience

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -322,7 +322,8 @@ class OIDCSessionFactory:
         return self._authorized_session
 
     def get_session_with_stored_token(
-        self, token_name: str = "ansys-openapi-common-oidc"
+        self,
+        token_name: str = "ansys-openapi-common-oidc",  # nosec B107
     ) -> requests.Session:
         """Create a :class:`OAuth2Session` object with a stored token.
 

--- a/src/ansys/openapi/common/_oidc.py
+++ b/src/ansys/openapi/common/_oidc.py
@@ -114,27 +114,19 @@ class OIDCConfiguration:
 
 
 class OIDCSessionFactory:
-    """
-    Creates an OpenID Connect session with the configuration fetched from the API server.
+    """Builds authenticated API sessions from OpenID Connect configuration.
 
-    This class uses either the provided token credentials or authorizes a user with a browser-based
-    interactive prompt.
+    Use :meth:`from_unauthorized_response` when parameters are discovered from a
+    ``401`` response, or :meth:`from_configuration` when settings are provided upfront.
 
-    Parameters
-    ----------
-    initial_session : requests.Session
-        Session to use while negotiating with the identity provider.
-    initial_response : requests.Response
-        Initial 401 response from the API server when no ``Authorization`` header is provided.
-    api_session_configuration : SessionConfiguration, optional
-        Configuration settings for connections to the API server.
-    idp_session_configuration : SessionConfiguration, optional
-        Configuration settings for connections to the OpenID identity provider.
+    Once constructed, the factory can supply a session using a stored token, a provided
+    refresh token, an access token, or an interactive browser login.
 
     Notes
     -----
-    The ``headers`` field in ``idp_session_configuration`` is not fully respected. The ``Accept`` and
-    ``Content-Type`` headers will be overridden. Other settings are respected.
+    The ``headers`` field in ``idp_session_configuration`` is not fully respected. The
+    ``Accept`` and ``Content-Type`` headers will be overridden. Other settings are
+    respected.
     """
 
     _api_url: str
@@ -145,20 +137,27 @@ class OIDCSessionFactory:
     _authorized_session: requests.Session
     _auth: OAuth2AuthorizationCodePKCE
 
-    def __init__(
-        self,
+    @classmethod
+    def _from_parsed_config(
+        cls,
+        api_url: str,
+        oidc_config: OIDCConfiguration,
         initial_session: requests.Session,
-        initial_response: requests.Response,
         api_session_configuration: Optional[SessionConfiguration] = None,
         idp_session_configuration: Optional[SessionConfiguration] = None,
-    ) -> None:
-        configured = OIDCSessionFactory.from_unauthorized_response(
+        *,
+        default_scopes: bool = False,
+    ) -> "OIDCSessionFactory":
+        factory = cls.__new__(cls)
+        factory._api_url = api_url
+        factory._oidc_config = oidc_config
+        factory._initialize_sessions(
             initial_session,
-            initial_response,
             api_session_configuration,
             idp_session_configuration,
         )
-        self.__dict__.update(configured.__dict__)
+        factory._configure_oauth(default_scopes=default_scopes)
+        return factory
 
     @classmethod
     def from_unauthorized_response(
@@ -168,22 +167,31 @@ class OIDCSessionFactory:
         api_session_configuration: Optional[SessionConfiguration] = None,
         idp_session_configuration: Optional[SessionConfiguration] = None,
     ) -> "OIDCSessionFactory":
-        """Create a factory using parameters from the API ``401`` response."""
-        factory = cls.__new__(cls)
-        factory._api_url = initial_response.url
+        """Create a factory using parameters from the API ``401`` response.
 
+        Parameters
+        ----------
+        initial_session : requests.Session
+            Session to use while negotiating with the identity provider.
+        initial_response : requests.Response
+            Initial ``401`` response from the API server when no ``Authorization`` header
+            is provided.
+        api_session_configuration : SessionConfiguration, optional
+            Configuration settings for connections to the API server.
+        idp_session_configuration : SessionConfiguration, optional
+            Configuration settings for connections to the OpenID identity provider.
+        """
         logger.debug("Creating OIDC session handler from unauthorized response...")
 
         bearer_parameters = cls._parse_unauthorized_header(initial_response)
-        factory._oidc_config = cls._oidc_config_from_bearer(bearer_parameters)
-
-        factory._initialize_sessions(
+        oidc_config = cls._oidc_config_from_bearer(bearer_parameters)
+        return cls._from_parsed_config(
+            initial_response.url,
+            oidc_config,
             initial_session,
             api_session_configuration,
             idp_session_configuration,
         )
-        factory._configure_oauth()
-        return factory
 
     @classmethod
     def from_configuration(
@@ -194,7 +202,21 @@ class OIDCSessionFactory:
         api_session_configuration: Optional[SessionConfiguration] = None,
         idp_session_configuration: Optional[SessionConfiguration] = None,
     ) -> "OIDCSessionFactory":
-        """Create a factory using upfront OpenID Connect configuration."""
+        """Create a factory using upfront OpenID Connect configuration.
+
+        Parameters
+        ----------
+        api_url : str
+            Base URL of the API server.
+        oidc_configuration : OIDCConfiguration
+            OpenID Connect provider settings.
+        initial_session : requests.Session
+            Session to use while negotiating with the identity provider.
+        api_session_configuration : SessionConfiguration, optional
+            Configuration settings for connections to the API server.
+        idp_session_configuration : SessionConfiguration, optional
+            Configuration settings for connections to the OpenID identity provider.
+        """
         if not oidc_configuration.client_id:
             raise ValueError("OIDC configuration must include client_id.")
 
@@ -210,19 +232,16 @@ class OIDCSessionFactory:
         ):
             raise ValueError(_ENDPOINT_CONFIGURATION_ERROR)
 
-        factory = cls.__new__(cls)
-        factory._api_url = api_url
-        factory._oidc_config = oidc_configuration
-
         logger.debug("Creating OIDC session handler from provided configuration...")
 
-        factory._initialize_sessions(
+        return cls._from_parsed_config(
+            api_url,
+            oidc_configuration,
             initial_session,
             api_session_configuration,
             idp_session_configuration,
+            default_scopes=True,
         )
-        factory._configure_oauth(default_scopes=True)
-        return factory
 
     def _initialize_sessions(
         self,

--- a/src/ansys/openapi/common/_oidc_config.py
+++ b/src/ansys/openapi/common/_oidc_config.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class OIDCConfiguration:
+    """OpenID Connect settings for API authentication.
+
+    When provided on :meth:`~ansys.openapi.common.ApiClientFactory.with_oidc`, the OIDC
+    session is configured without contacting the API for a ``401`` response.
+
+    Parameters
+    ----------
+    client_id : str, optional
+        OAuth client identifier. Maps from the ``clientid`` ``WWW-Authenticate`` parameter.
+    authority : str, optional
+        Identity provider authority URL from a ``401`` response. Used only for legacy
+        API-driven discovery when ``well_known_url`` and explicit endpoints are not set.
+    authorization_endpoint : str, optional
+        Authorization endpoint URL. When set together with ``token_endpoint``,
+        the well-known endpoint is not contacted.
+    token_endpoint : str, optional
+        Token endpoint URL.
+    well_known_url : str, optional
+        OpenID Provider metadata URL. When provided without explicit endpoints,
+        ``authorization_endpoint`` and ``token_endpoint`` are fetched from this URL.
+    scopes : list[str], optional
+        OAuth scopes to request. Maps from the ``scope`` ``WWW-Authenticate`` parameter.
+    api_audience : str, optional
+        API audience for Auth0-style providers. Maps from the ``apiAudience``
+        ``WWW-Authenticate`` parameter. Omit for Azure AD B2C.
+    redirect_uri : str, optional
+        Registered redirect URI for the interactive login flow. Maps from the
+        ``redirecturi`` ``WWW-Authenticate`` parameter.
+    redirect_uri_port : int, optional
+        Local port used for the browser redirect when ``redirect_uri`` is not set.
+        The default is ``32284``.
+    """
+
+    client_id: Optional[str] = None
+    authority: Optional[str] = None
+    authorization_endpoint: Optional[str] = None
+    token_endpoint: Optional[str] = None
+    well_known_url: Optional[str] = None
+    scopes: Optional[List[str]] = None
+    api_audience: Optional[str] = None
+    redirect_uri: Optional[str] = None
+    redirect_uri_port: int = 32284
+
+    def is_complete(self) -> bool:
+        """Return whether enough configuration is present to skip ``401`` discovery."""
+        if not self.client_id:
+            return False
+        if self.authorization_endpoint and self.token_endpoint:
+            return True
+        return bool(self.well_known_url)
+
+    def has_explicit_endpoints(self) -> bool:
+        """Return whether both OAuth endpoints were provided directly."""
+        return bool(self.authorization_endpoint and self.token_endpoint)
+
+    def has_partial_endpoints(self) -> bool:
+        """Return whether only one OAuth endpoint was provided."""
+        return (
+            bool(self.authorization_endpoint or self.token_endpoint)
+            and not self.has_explicit_endpoints()
+        )

--- a/src/ansys/openapi/common/_oidc_config.py
+++ b/src/ansys/openapi/common/_oidc_config.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 - 2026 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
 #
 #
@@ -19,6 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+
 from dataclasses import dataclass
 from typing import List, Optional
 

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -508,7 +508,7 @@ class OIDCSessionBuilder:
         self._client_factory = client_factory
         self._session_factory = session_factory
 
-    def with_stored_token(self, token_name: str = "ansys-openapi-common-oidc") -> ApiClientFactory:
+    def with_stored_token(self, token_name: str = "ansys-openapi-common-oidc") -> ApiClientFactory:  # nosec B107
         """Use a token stored in the system keyring to authenticate the session.
 
         This method requires a correctly configured system keyring backend.

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -55,7 +55,7 @@ try:
     import keyring
     import requests_auth  # type: ignore[import-untyped, unused-ignore]  # noqa: F401
 
-    from ._oidc import OIDCSessionFactory
+    from ._oidc import OIDCConfiguration, OIDCSessionFactory
 except ImportError:
     _oidc_enabled = False
 
@@ -353,6 +353,7 @@ class ApiClientFactory:
     def with_oidc(
         self,
         idp_session_configuration: Optional[SessionConfiguration] = None,
+        oidc_configuration: "Optional[OIDCConfiguration]" = None,
     ) -> "OIDCSessionBuilder":
         """Set up client authentication for use with OpenID Connect.
 
@@ -360,6 +361,11 @@ class ApiClientFactory:
         ----------
         idp_session_configuration : ~ansys.openapi.common.SessionConfiguration, optional
             Additional configuration settings for the requests session when connected to the OpenID identity provider.
+        oidc_configuration : ~ansys.openapi.common.OIDCConfiguration, optional
+            OpenID Connect provider settings. When omitted, authentication parameters are discovered
+            from the API ``401`` response. When provided, explicit ``authorization_endpoint`` and
+            ``token_endpoint`` values are used if set; otherwise ``well_known_url`` is used to
+            discover them.
 
         Returns
         -------
@@ -374,11 +380,22 @@ class ApiClientFactory:
             raise ImportError(
                 "OpenID Connect features are not enabled. To use them, run `pip install ansys-openapi-common[oidc]`."
             )
+
+        if oidc_configuration is not None:
+            session_factory = OIDCSessionFactory.from_configuration(
+                self._api_url,
+                oidc_configuration,
+                self._session,
+                self._session_configuration,
+                idp_session_configuration,
+            )
+            return OIDCSessionBuilder(self, session_factory)
+
         initial_response = self._session.get(self._api_url)
         if self.__handle_initial_response(initial_response):
             return OIDCSessionBuilder(self)
 
-        session_factory = OIDCSessionFactory(
+        session_factory = OIDCSessionFactory.from_unauthorized_response(
             self._session,
             initial_response,
             self._session_configuration,

--- a/src/ansys/openapi/common/_session.py
+++ b/src/ansys/openapi/common/_session.py
@@ -35,6 +35,7 @@ from . import __version__
 from ._api_client import ApiClient
 from ._exceptions import ApiConnectionException, AuthenticationWarning
 from ._logger import logger
+from ._oidc_config import OIDCConfiguration
 from ._util import (
     CaseInsensitiveOrderedDict,
     SessionConfiguration,
@@ -55,7 +56,7 @@ try:
     import keyring
     import requests_auth  # type: ignore[import-untyped, unused-ignore]  # noqa: F401
 
-    from ._oidc import OIDCConfiguration, OIDCSessionFactory
+    from ._oidc import OIDCSessionFactory
 except ImportError:
     _oidc_enabled = False
 
@@ -353,7 +354,7 @@ class ApiClientFactory:
     def with_oidc(
         self,
         idp_session_configuration: Optional[SessionConfiguration] = None,
-        oidc_configuration: "Optional[OIDCConfiguration]" = None,
+        oidc_configuration: Optional[OIDCConfiguration] = None,
     ) -> "OIDCSessionBuilder":
         """Set up client authentication for use with OpenID Connect.
 

--- a/tests/test_missing_imports.py
+++ b/tests/test_missing_imports.py
@@ -42,7 +42,11 @@ def get_package_name() -> str:
 class TestMissingExtras:
     real_import = __import__
     blocked_import = ""
-    base_module_list = ["ansys.openapi.common._session", "ansys.openapi.common"]
+    base_module_list = [
+        "ansys.openapi.common._session",
+        "ansys.openapi.common._oidc",
+        "ansys.openapi.common",
+    ]
 
     @pytest.fixture(autouse=True)
     def module_clearing_fixture(self):
@@ -68,6 +72,14 @@ class TestMissingExtras:
 
         package_name = get_package_name()
         assert f"`pip install {package_name}[oidc]`" in str(excinfo.value)
+
+    def test_oidc_configuration_is_none_without_oidc_extra(self, mocker):
+        self.blocked_import = "requests_auth"
+        mocker.patch("builtins.__import__", side_effect=self.mocked_import)
+
+        import ansys.openapi.common as common
+
+        assert common.OIDCConfiguration is None
 
     @pytest.mark.skipif(os.name == "nt", reason="Test only applies to linux")
     def test_create_autologon_on_linux_with_no_extra_throws(self, mocker):

--- a/tests/test_missing_imports.py
+++ b/tests/test_missing_imports.py
@@ -45,6 +45,7 @@ class TestMissingExtras:
     base_module_list = [
         "ansys.openapi.common._session",
         "ansys.openapi.common._oidc",
+        "ansys.openapi.common._oidc_config",
         "ansys.openapi.common",
     ]
 
@@ -73,13 +74,14 @@ class TestMissingExtras:
         package_name = get_package_name()
         assert f"`pip install {package_name}[oidc]`" in str(excinfo.value)
 
-    def test_oidc_configuration_is_none_without_oidc_extra(self, mocker):
+    def test_oidc_configuration_is_available_without_oidc_extra(self, mocker):
         self.blocked_import = "requests_auth"
         mocker.patch("builtins.__import__", side_effect=self.mocked_import)
 
         import ansys.openapi.common as common
 
-        assert common.OIDCConfiguration is None
+        config = common.OIDCConfiguration(client_id="client")
+        assert config.client_id == "client"
 
     @pytest.mark.skipif(os.name == "nt", reason="Test only applies to linux")
     def test_create_autologon_on_linux_with_no_extra_throws(self, mocker):

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -467,43 +467,6 @@ def test_redirect_uri_from_configuration_is_wired():
     }
 
 
-def _unauthorized_oidc_response(api_url: str, authority_url: str) -> requests.Response:
-    response = requests.Response()
-    response.url = api_url
-    response.status_code = 401
-    response.headers["WWW-Authenticate"] = (
-        f'Bearer redirecturi="{REQUIRED_HEADERS["redirecturi"]}", '
-        f'authority="{authority_url}", clientid="{REQUIRED_HEADERS["clientid"]}"'
-    )
-    return response
-
-
-def test_oidc_session_factory_init_delegates_to_unauthorized_response():
-    api_url = "https://api.example.com/v1"
-    authority_url = "https://www.example.com/authority/"
-    response = _unauthorized_oidc_response(api_url, authority_url)
-    well_known_response = json.dumps(
-        {
-            "token_endpoint": f"{authority_url}token",
-            "authorization_endpoint": f"{authority_url}authorization",
-        }
-    )
-
-    with requests_mock.Mocker() as m:
-        m.get(
-            f"{authority_url}.well-known/openid-configuration",
-            status_code=200,
-            text=well_known_response,
-        )
-        initial_session = requests.Session()
-        via_init = OIDCSessionFactory(initial_session, response)
-        via_classmethod = OIDCSessionFactory.from_unauthorized_response(initial_session, response)
-
-        assert via_init._api_url == via_classmethod._api_url
-        assert via_init._oidc_config.client_id == via_classmethod._oidc_config.client_id
-        assert via_init._auth.token_url == via_classmethod._auth.token_url
-
-
 def test_from_configuration_without_client_id_raises():
     config = OIDCConfiguration(
         well_known_url="https://idp.example.com/.well-known/openid-configuration"

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -30,7 +30,7 @@ import requests
 from requests_auth import OAuth2
 import requests_mock
 
-from ansys.openapi.common import ApiClientFactory
+from ansys.openapi.common import ApiClientFactory, OIDCConfiguration
 from ansys.openapi.common._oidc import OIDCSessionFactory
 
 REQUIRED_HEADERS = {
@@ -107,16 +107,17 @@ def test_valid_header_returns_correct_values(authenticate_parsing_fixture):
 
 
 @pytest.mark.parametrize(
-    "authority_url",
-    ["https://www.example.com/", "https://www.example.com", "https://www.example.com/api/"],
+    "well_known_url",
+    [
+        "https://www.example.com/.well-known/openid-configuration",
+        "https://www.example.com/api/.well-known/openid-configuration",
+    ],
 )
-def test_valid_well_known_parsed_correctly(authority_url):
+def test_valid_well_known_parsed_correctly(well_known_url):
     response = json.dumps(WELL_KNOWN_PARAMETERS)
     with requests_mock.Mocker() as requests_mocker:
-        if not authority_url.endswith("/"):
-            authority_url += "/"
         requests_mocker.get(
-            f"{authority_url}.well-known/openid-configuration",
+            well_known_url,
             status_code=200,
             text=response,
         )
@@ -124,7 +125,7 @@ def test_valid_well_known_parsed_correctly(authority_url):
         mock_factory._oauth_requests_session = requests.Session()
         mock_factory._idp_session_configuration = {}
         mock_factory._api_session_configuration = {}
-        output = OIDCSessionFactory._fetch_and_parse_well_known(mock_factory, authority_url)
+        output = OIDCSessionFactory._fetch_and_parse_well_known(mock_factory, well_known_url)
         for k, v in WELL_KNOWN_PARAMETERS.items():
             assert output[k] == v
             assert output[k.upper()] == v
@@ -135,10 +136,10 @@ def test_missing_well_known_parameters_throws(missing_parameter):
     parameters = WELL_KNOWN_PARAMETERS.copy()
     del parameters[missing_parameter]
     response = json.dumps(parameters)
-    identity_provider_url = "http://www.example.com/"
+    identity_provider_url = "http://www.example.com/.well-known/openid-configuration"
     with requests_mock.Mocker() as requests_mocker:
         requests_mocker.get(
-            "{}.well-known/openid-configuration".format(identity_provider_url),
+            identity_provider_url,
             status_code=200,
             text=response,
         )
@@ -155,10 +156,10 @@ def test_missing_well_known_parameters_throws(missing_parameter):
 def test_multiple_missing_well_known_parameters_throws():
     parameters = {}
     response = json.dumps(parameters)
-    identity_provider_url = "http://www.example.com/"
+    identity_provider_url = "http://www.example.com/.well-known/openid-configuration"
     with requests_mock.Mocker() as requests_mocker:
         requests_mocker.get(
-            "{}.well-known/openid-configuration".format(identity_provider_url),
+            identity_provider_url,
             status_code=200,
             text=response,
         )
@@ -342,3 +343,124 @@ def mock_oidc_session_builder():
 
         session_builder = ApiClientFactory(secure_servicelayer_url).with_oidc()
     return session_builder
+
+
+def test_oidc_configuration_is_complete_with_well_known_url():
+    config = OIDCConfiguration(
+        client_id="client",
+        well_known_url="https://idp.example.com/.well-known/openid-configuration",
+    )
+    assert config.is_complete()
+
+
+def test_oidc_configuration_is_complete_with_endpoints():
+    config = OIDCConfiguration(
+        client_id="client",
+        authorization_endpoint="https://idp.example.com/auth",
+        token_endpoint="https://idp.example.com/token",
+    )
+    assert config.is_complete()
+
+
+def test_oidc_configuration_is_incomplete_without_client_id():
+    config = OIDCConfiguration(
+        well_known_url="https://idp.example.com/.well-known/openid-configuration"
+    )
+    assert not config.is_complete()
+
+
+def test_oidc_configuration_is_incomplete_without_endpoint_source():
+    config = OIDCConfiguration(client_id="client")
+    assert not config.is_complete()
+
+
+def test_oidc_configuration_with_partial_endpoints_raises():
+    config = OIDCConfiguration(
+        client_id="client",
+        authorization_endpoint="https://idp.example.com/auth",
+    )
+    with pytest.raises(ValueError, match="both authorization_endpoint and token_endpoint"):
+        OIDCSessionFactory.from_configuration(
+            "https://api.example.com",
+            config,
+            requests.Session(),
+        )
+
+
+def test_oidc_configuration_without_endpoint_source_raises():
+    config = OIDCConfiguration(client_id="client")
+    with pytest.raises(ValueError, match="well_known_url or both"):
+        OIDCSessionFactory.from_configuration(
+            "https://api.example.com",
+            config,
+            requests.Session(),
+        )
+
+
+def test_upfront_oidc_configuration_skips_api_call():
+    api_url = "https://localhost/mi_servicelayer"
+    authority_url = "https://contoso.b2clogin.com/contoso.onmicrosoft.com/b2c_1_susi"
+    well_known_url = f"{authority_url}/v2.0/.well-known/openid-configuration"
+    client_id = "b4e44bfa-6b73-4d6a-9df6-8055216a5836"
+    well_known_response = json.dumps(
+        {
+            "token_endpoint": f"{authority_url}/oauth2/v2.0/token",
+            "authorization_endpoint": f"{authority_url}/oauth2/v2.0/authorize",
+        }
+    )
+
+    oidc_configuration = OIDCConfiguration(
+        client_id=client_id,
+        well_known_url=well_known_url,
+        scopes=["openid", "offline_access"],
+    )
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            well_known_url,
+            status_code=200,
+            text=well_known_response,
+        )
+        session_builder = ApiClientFactory(api_url).with_oidc(oidc_configuration=oidc_configuration)
+        auth = session_builder._session_factory._auth
+
+        assert all(api_url not in str(request.url) for request in m.request_history)
+        assert auth.token_url == f"{authority_url}/oauth2/v2.0/token"
+        assert auth.refresh_data["client_id"] == client_id
+        assert auth.refresh_data["scope"] == "openid offline_access"
+
+
+def test_upfront_oidc_configuration_skips_well_known_when_endpoints_provided():
+    api_url = "https://localhost/mi_servicelayer"
+    client_id = "b4e44bfa-6b73-4d6a-9df6-8055216a5836"
+    authorization_endpoint = "https://idp.example.com/auth"
+    token_endpoint = "https://idp.example.com/token"
+    well_known_url = "https://idp.example.com/.well-known/openid-configuration"
+
+    oidc_configuration = OIDCConfiguration(
+        client_id=client_id,
+        well_known_url=well_known_url,
+        authorization_endpoint=authorization_endpoint,
+        token_endpoint=token_endpoint,
+    )
+
+    with requests_mock.Mocker() as m:
+        session_builder = ApiClientFactory(api_url).with_oidc(oidc_configuration=oidc_configuration)
+        auth = session_builder._session_factory._auth
+
+        assert not m.called
+        assert auth.token_url == token_endpoint
+
+
+def test_redirect_uri_from_configuration_is_wired():
+    config = OIDCConfiguration(
+        client_id="client",
+        well_known_url="https://idp.example.com/.well-known/openid-configuration",
+        redirect_uri="http://localhost:1729/callback",
+    )
+    kwargs = OIDCSessionFactory._redirect_uri_kwargs(config)
+    assert kwargs == {
+        "redirect_uri_domain": "localhost",
+        "redirect_uri_port": 1729,
+        "redirect_uri_endpoint": "callback",
+    }

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -453,18 +453,83 @@ def test_upfront_oidc_configuration_skips_well_known_when_endpoints_provided():
         assert auth.token_url == token_endpoint
 
 
-def test_redirect_uri_from_configuration_is_wired():
+@pytest.mark.parametrize(
+    ("redirect_uri", "redirect_uri_port", "expected"),
+    [
+        (
+            "http://localhost:1729/callback",
+            32284,
+            {
+                "redirect_uri_domain": "localhost",
+                "redirect_uri_port": 1729,
+                "redirect_uri_endpoint": "callback",
+            },
+        ),
+        (
+            "https://callback.example.com/oauth/callback",
+            32284,
+            {
+                "redirect_uri_domain": "callback.example.com",
+                "redirect_uri_port": 443,
+                "redirect_uri_endpoint": "oauth/callback",
+            },
+        ),
+        (
+            "http://callback.example.com/oauth/callback",
+            32284,
+            {
+                "redirect_uri_domain": "callback.example.com",
+                "redirect_uri_port": 80,
+                "redirect_uri_endpoint": "oauth/callback",
+            },
+        ),
+        (
+            "https://callback.example.com:8443/callback",
+            32284,
+            {
+                "redirect_uri_domain": "callback.example.com",
+                "redirect_uri_port": 8443,
+                "redirect_uri_endpoint": "callback",
+            },
+        ),
+        (
+            "http://127.0.0.1:8080/",
+            32284,
+            {
+                "redirect_uri_domain": "127.0.0.1",
+                "redirect_uri_port": 8080,
+                "redirect_uri_endpoint": "",
+            },
+        ),
+        (
+            "https://127.0.0.1",
+            32284,
+            {
+                "redirect_uri_domain": "127.0.0.1",
+                "redirect_uri_port": 443,
+                "redirect_uri_endpoint": "",
+            },
+        ),
+        (
+            None,
+            32284,
+            {"redirect_uri_port": 32284},
+        ),
+        (
+            None,
+            49152,
+            {"redirect_uri_port": 49152},
+        ),
+    ],
+)
+def test_redirect_uri_kwargs(redirect_uri, redirect_uri_port, expected):
     config = OIDCConfiguration(
         client_id="client",
         well_known_url="https://idp.example.com/.well-known/openid-configuration",
-        redirect_uri="http://localhost:1729/callback",
+        redirect_uri=redirect_uri,
+        redirect_uri_port=redirect_uri_port,
     )
-    kwargs = OIDCSessionFactory._redirect_uri_kwargs(config)
-    assert kwargs == {
-        "redirect_uri_domain": "localhost",
-        "redirect_uri_port": 1729,
-        "redirect_uri_endpoint": "callback",
-    }
+    assert OIDCSessionFactory._redirect_uri_kwargs(config) == expected
 
 
 def test_from_configuration_without_client_id_raises():

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -27,6 +27,7 @@ from urllib.parse import parse_qs
 from covertable import make
 import pytest
 import requests
+from requests.models import CaseInsensitiveDict
 from requests_auth import OAuth2
 import requests_mock
 
@@ -464,3 +465,152 @@ def test_redirect_uri_from_configuration_is_wired():
         "redirect_uri_port": 1729,
         "redirect_uri_endpoint": "callback",
     }
+
+
+def _unauthorized_oidc_response(api_url: str, authority_url: str) -> requests.Response:
+    response = requests.Response()
+    response.url = api_url
+    response.status_code = 401
+    response.headers["WWW-Authenticate"] = (
+        f'Bearer redirecturi="{REQUIRED_HEADERS["redirecturi"]}", '
+        f'authority="{authority_url}", clientid="{REQUIRED_HEADERS["clientid"]}"'
+    )
+    return response
+
+
+def test_oidc_session_factory_init_delegates_to_unauthorized_response():
+    api_url = "https://api.example.com/v1"
+    authority_url = "https://www.example.com/authority/"
+    response = _unauthorized_oidc_response(api_url, authority_url)
+    well_known_response = json.dumps(
+        {
+            "token_endpoint": f"{authority_url}token",
+            "authorization_endpoint": f"{authority_url}authorization",
+        }
+    )
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{authority_url}.well-known/openid-configuration",
+            status_code=200,
+            text=well_known_response,
+        )
+        initial_session = requests.Session()
+        via_init = OIDCSessionFactory(initial_session, response)
+        via_classmethod = OIDCSessionFactory.from_unauthorized_response(initial_session, response)
+
+        assert via_init._api_url == via_classmethod._api_url
+        assert via_init._oidc_config.client_id == via_classmethod._oidc_config.client_id
+        assert via_init._auth.token_url == via_classmethod._auth.token_url
+
+
+def test_from_configuration_without_client_id_raises():
+    config = OIDCConfiguration(
+        well_known_url="https://idp.example.com/.well-known/openid-configuration"
+    )
+    with pytest.raises(ValueError, match="client_id"):
+        OIDCSessionFactory.from_configuration(
+            "https://api.example.com",
+            config,
+            requests.Session(),
+        )
+
+
+def test_initialize_sessions_uses_default_session_configuration():
+    config = OIDCConfiguration(
+        client_id="client",
+        authorization_endpoint="https://idp.example.com/auth",
+        token_endpoint="https://idp.example.com/token",  # nosec B106
+    )
+    factory = OIDCSessionFactory.from_configuration(
+        "https://api.example.com",
+        config,
+        requests.Session(),
+        api_session_configuration=None,
+        idp_session_configuration=None,
+    )
+
+    assert factory._api_session_configuration["verify"] is True
+    assert factory._idp_session_configuration["headers"]["accept"] == "application/json"
+
+
+def test_oidc_config_from_bearer_accepts_scope_list():
+    bearer_parameters = CaseInsensitiveDict(
+        {
+            **REQUIRED_HEADERS,
+            "scope": ["openid", "offline_access", "profile"],
+        }
+    )
+    config = OIDCSessionFactory._oidc_config_from_bearer(bearer_parameters)
+    assert config.scopes == ["openid", "offline_access", "profile"]
+
+
+def test_oidc_config_from_bearer_maps_api_audience():
+    api_audience = "https://contoso.onmicrosoft.com/api"
+    bearer_parameters = CaseInsensitiveDict({**REQUIRED_HEADERS, "apiAudience": api_audience})
+    config = OIDCSessionFactory._oidc_config_from_bearer(bearer_parameters)
+    assert config.api_audience == api_audience
+
+
+def test_api_audience_is_wired_from_upfront_configuration():
+    api_url = "https://localhost/mi_servicelayer"
+    api_audience = "https://contoso.onmicrosoft.com/api"
+    oidc_configuration = OIDCConfiguration(
+        client_id="client",
+        authorization_endpoint="https://idp.example.com/auth",
+        token_endpoint="https://idp.example.com/token",  # nosec B106
+        api_audience=api_audience,
+        scopes=["openid", "offline_access"],
+    )
+
+    factory = OIDCSessionFactory.from_configuration(api_url, oidc_configuration, requests.Session())
+
+    assert factory._api_session_configuration["headers"]["audience"] == api_audience
+    assert factory._idp_session_configuration["headers"]["audience"] == api_audience
+    assert "audience" not in factory._auth.refresh_data
+
+
+def test_api_audience_is_wired_from_unauthorized_response():
+    api_url = "https://api.example.com/v1"
+    authority_url = "https://www.example.com/authority/"
+    api_audience = "https://api.example.com/audience"
+    response = requests.Response()
+    response.url = api_url
+    response.status_code = 401
+    response.headers["WWW-Authenticate"] = (
+        f'Bearer redirecturi="{REQUIRED_HEADERS["redirecturi"]}", '
+        f'authority="{authority_url}", clientid="{REQUIRED_HEADERS["clientid"]}", '
+        f'apiAudience="{api_audience}"'
+    )
+    well_known_response = json.dumps(
+        {
+            "token_endpoint": f"{authority_url}token",
+            "authorization_endpoint": f"{authority_url}authorization",
+        }
+    )
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            f"{authority_url}.well-known/openid-configuration",
+            status_code=200,
+            text=well_known_response,
+        )
+        factory = OIDCSessionFactory.from_unauthorized_response(requests.Session(), response)
+
+    assert factory._api_session_configuration["headers"]["audience"] == api_audience
+    assert factory._oidc_config.api_audience == api_audience
+
+
+def test_missing_single_well_known_parameter_uses_singular_error_message():
+    parameters = {"authorization_endpoint": WELL_KNOWN_PARAMETERS["authorization_endpoint"]}
+    identity_provider_url = "http://www.example.com/.well-known/openid-configuration"
+    with requests_mock.Mocker() as requests_mocker:
+        requests_mocker.get(
+            identity_provider_url,
+            status_code=200,
+            text=json.dumps(parameters),
+        )
+        mock_factory = Mock()
+        mock_factory._oauth_requests_session = requests.Session()
+        with pytest.raises(ConnectionError, match="Well-known parameter 'token_endpoint'"):
+            OIDCSessionFactory._fetch_and_parse_well_known(mock_factory, identity_provider_url)

--- a/tests/test_oidc.py
+++ b/tests/test_oidc.py
@@ -357,7 +357,7 @@ def test_oidc_configuration_is_complete_with_endpoints():
     config = OIDCConfiguration(
         client_id="client",
         authorization_endpoint="https://idp.example.com/auth",
-        token_endpoint="https://idp.example.com/token",
+        token_endpoint="https://idp.example.com/token",  # nosec B106
     )
     assert config.is_complete()
 
@@ -434,7 +434,7 @@ def test_upfront_oidc_configuration_skips_well_known_when_endpoints_provided():
     api_url = "https://localhost/mi_servicelayer"
     client_id = "b4e44bfa-6b73-4d6a-9df6-8055216a5836"
     authorization_endpoint = "https://idp.example.com/auth"
-    token_endpoint = "https://idp.example.com/token"
+    token_endpoint = "https://idp.example.com/token"  # nosec B105
     well_known_url = "https://idp.example.com/.well-known/openid-configuration"
 
     oidc_configuration = OIDCConfiguration(

--- a/uv.lock
+++ b/uv.lock
@@ -88,9 +88,7 @@ dev-linux = [
 ]
 doc = [
     { name = "ansys-sphinx-theme" },
-    { name = "keyring" },
     { name = "numpydoc" },
-    { name = "requests-auth" },
     { name = "sphinx" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
@@ -130,9 +128,7 @@ dev = [
 dev-linux = [{ name = "asgi-gssapi", marker = "sys_platform == 'linux'" }]
 doc = [
     { name = "ansys-sphinx-theme", specifier = "==1.9.0" },
-    { name = "keyring", specifier = ">=22,<26" },
     { name = "numpydoc", specifier = "==1.10.0" },
-    { name = "requests-auth", specifier = ">=8.0.0,<9.0.0" },
     { name = "sphinx", specifier = "==8.1.3" },
     { name = "sphinx-copybutton", specifier = "==0.5.2" },
     { name = "sphinx-design", specifier = "==0.6.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -88,7 +88,9 @@ dev-linux = [
 ]
 doc = [
     { name = "ansys-sphinx-theme" },
+    { name = "keyring" },
     { name = "numpydoc" },
+    { name = "requests-auth" },
     { name = "sphinx" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
@@ -128,7 +130,9 @@ dev = [
 dev-linux = [{ name = "asgi-gssapi", marker = "sys_platform == 'linux'" }]
 doc = [
     { name = "ansys-sphinx-theme", specifier = "==1.9.0" },
+    { name = "keyring", specifier = ">=22,<26" },
     { name = "numpydoc", specifier = "==1.10.0" },
+    { name = "requests-auth", specifier = ">=8.0.0,<9.0.0" },
     { name = "sphinx", specifier = "==8.1.3" },
     { name = "sphinx-copybutton", specifier = "==0.5.2" },
     { name = "sphinx-design", specifier = "==0.6.1" },


### PR DESCRIPTION
## Summary
- Add `OIDCConfiguration` so callers can supply OpenID Connect provider settings directly on `with_oidc()`
- Support explicit OAuth endpoints or discovery from a provided `well_known_url`; omit `oidc_configuration` to keep the existing `401`/`WWW-Authenticate` discovery flow
- Wire `redirect_uri` from configuration and fix sending `audience=None` in authorization requests

## Test plan
- [x] `uv run pytest tests/test_oidc.py tests/test_session_creation.py -q`
- [x] Manual verification against Azure AD B2C test tenant (Grant MI API)

Made with [Cursor](https://cursor.com)