### PR TITLE
Extract serializer and deserializer from ApiClient

### DIFF
--- a/doc/changelog.d/1089.added.md
+++ b/doc/changelog.d/1089.added.md
@@ -1,0 +1,1 @@
+Extract serializer and deserializer from ApiClient

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -44,12 +44,6 @@ from urllib.parse import quote
 import requests
 
 from ._base import ApiClientBase, DeserializedType, ModelBase, PrimitiveType, SerializedType
-from ._codec_types import (
-    DICT_MATCH_REGEX,
-    LIST_MATCH_REGEX,
-    NATIVE_TYPES_MAPPING,
-    PRIMITIVE_TYPES,
-)
 from ._deserializer import Deserializer
 from ._exceptions import ApiException
 from ._logger import logger
@@ -95,11 +89,6 @@ class ApiClient(ApiClientBase):
     ... ssl_client
     <ApiClient url: https://secure-api/API/v1.svc>
     """
-
-    PRIMITIVE_TYPES = PRIMITIVE_TYPES
-    NATIVE_TYPES_MAPPING = NATIVE_TYPES_MAPPING
-    LIST_MATCH_REGEX = LIST_MATCH_REGEX
-    DICT_MATCH_REGEX = DICT_MATCH_REGEX
 
     def __init__(
         self,

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -20,13 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import datetime
-from enum import Enum
 import json
 import mimetypes
 import os
-import re
-import tempfile
+from enum import Enum
 from types import ModuleType
 from typing import (
     IO,
@@ -43,14 +40,21 @@ from typing import (
     cast,
 )
 from urllib.parse import quote
-import warnings
 
-from dateutil.parser import parse
 import requests
 
-from ._base import ApiClientBase, DeserializedType, ModelBase, PrimitiveType, SerializedType, Unset
-from ._exceptions import ApiException, UndefinedObjectWarning
+from ._base import ApiClientBase, DeserializedType, ModelBase, PrimitiveType, SerializedType
+from ._codec_types import (
+    DICT_MATCH_REGEX,
+    LIST_MATCH_REGEX,
+    NATIVE_TYPES_MAPPING,
+    PRIMITIVE_TYPES,
+)
+from ._deserializer import Deserializer
+from ._exceptions import ApiException
 from ._logger import logger
+from ._model_registry import ModelRegistry
+from ._serializer import Serializer
 from ._util import SessionConfiguration
 
 
@@ -92,18 +96,10 @@ class ApiClient(ApiClientBase):
     <ApiClient url: https://secure-api/API/v1.svc>
     """
 
-    PRIMITIVE_TYPES = (float, bool, bytes, str, int)
-    NATIVE_TYPES_MAPPING = {
-        "int": int,
-        "bytes": bytes,
-        "float": float,
-        "str": str,
-        "bool": bool,
-        "date": datetime.date,
-        "datetime": datetime.datetime,
-    }
-    LIST_MATCH_REGEX = re.compile(r"list\[(.*)]")
-    DICT_MATCH_REGEX = re.compile(r"dict\(([^,]*), (.*)\)")
+    PRIMITIVE_TYPES = PRIMITIVE_TYPES
+    NATIVE_TYPES_MAPPING = NATIVE_TYPES_MAPPING
+    LIST_MATCH_REGEX = LIST_MATCH_REGEX
+    DICT_MATCH_REGEX = DICT_MATCH_REGEX
 
     def __init__(
         self,
@@ -111,10 +107,20 @@ class ApiClient(ApiClientBase):
         api_url: str,
         configuration: SessionConfiguration,
     ):
-        self.models: Dict[str, Union[Type[ModelBase], Type[Enum]]] = {}
+        self._model_registry = ModelRegistry()
+        self._serializer = Serializer()
+        self._deserializer = Deserializer(
+            self._model_registry,
+            temp_folder_path=configuration.temp_folder_path,
+        )
         self.api_url = api_url
         self.rest_client = session
         self.configuration = configuration
+
+    @property
+    def models(self) -> Dict[str, Union[Type[ModelBase], Type[Enum]]]:
+        """Registered model and enum classes keyed by their OpenAPI type name."""
+        return self._model_registry.models
 
     def __repr__(self) -> str:
         """Printable representation of the object."""
@@ -138,7 +144,7 @@ class ApiClient(ApiClientBase):
         ... import ApiModels as model_module
         ... client.setup_client(model_module)
         """
-        self.models = models.__dict__
+        self._model_registry.register_module(models)
 
     def __call_api(
         self,
@@ -285,29 +291,7 @@ class ApiClient(ApiClientBase):
         ... client.sanitize_for_serialization(datetime.datetime(2015, 10, 21, 10, 5, 10))
         '2015-10-21T10:05:10'
         """
-        if obj is None:
-            return None
-        elif isinstance(obj, self.PRIMITIVE_TYPES):
-            return obj
-        elif isinstance(obj, list):
-            return [self.sanitize_for_serialization(sub_obj) for sub_obj in obj]
-        elif isinstance(obj, tuple):
-            return tuple(self.sanitize_for_serialization(sub_obj) for sub_obj in obj)
-        elif isinstance(obj, (datetime.datetime, datetime.date)):
-            return obj.isoformat()
-        elif isinstance(obj, Enum):
-            return obj.value
-
-        if isinstance(obj, dict):
-            obj_dict = obj
-        else:
-            obj_dict = {
-                obj.attribute_map[attr]: getattr(obj, attr)
-                for attr in obj.swagger_types
-                if getattr(obj, attr) is not Unset
-            }
-
-        return {key: self.sanitize_for_serialization(val) for key, val in obj_dict.items()}
+        return self._serializer.serialize(obj)
 
     def deserialize(
         self, response: requests.Response, response_type: Optional[str]
@@ -354,7 +338,7 @@ class ApiClient(ApiClientBase):
             return None
 
         if response_type == "file":
-            return self.__deserialize_file(response)
+            return self._deserializer.deserialize_response(response, response_type)
 
         if response_type == "str":
             data: SerializedType = response.text
@@ -367,79 +351,8 @@ class ApiClient(ApiClientBase):
         return self.__deserialize(data, response_type)
 
     def __deserialize(self, data: SerializedType, klass_name: str) -> DeserializedType:
-        """Deserialize ``dict``, ``list``, and ``str`` into an object.
-
-        Parameters
-        ----------
-        data : Union[dict, list, str]
-            Response data to deserialize.
-        klass_name : str
-            Type of object to deserialize the data to. The type can be a:
-
-            * String class name
-            * String type definition for list or dictionary
-            * "object" literal, which returns the dictionary as-is
-        """
-        if data is None:
-            return None
-
-        if klass_name == "object":
-            warnings.warn(
-                "Attempting to deserialize an object with no defined type. Returning "
-                "the raw data as a dictionary. Check your OpenAPI definition and ensure "
-                "all types are fully defined.",
-                UndefinedObjectWarning,
-            )
-            return data
-
-        list_match = self.LIST_MATCH_REGEX.match(klass_name)
-        if list_match is not None:
-            if not isinstance(data, list):
-                raise TypeError(
-                    f"Expected list for deserializing to {klass_name}, got {type(data)}"
-                )
-            sub_kls = list_match.group(1)
-            return [self.__deserialize(sub_data, sub_kls) for sub_data in data]
-
-        dict_match = self.DICT_MATCH_REGEX.match(klass_name)
-        if dict_match is not None:
-            if not isinstance(data, dict):
-                raise TypeError(
-                    f"Expected dict for deserializing to {klass_name}, got {type(data)}"
-                )
-            sub_kls = dict_match.group(2)
-            return {k: self.__deserialize(v, sub_kls) for k, v in data.items()}
-
-        if klass_name in self.NATIVE_TYPES_MAPPING:
-            klass = self.NATIVE_TYPES_MAPPING[klass_name]
-            if klass in self.PRIMITIVE_TYPES:
-                if not isinstance(data, (str, int, float, bool, bytes)):
-                    raise TypeError(
-                        f"Expected primitive type for deserializing to {klass_name}, got {type(data)}"
-                    )
-                return self.__deserialize_primitive(data, klass)
-            elif klass == datetime.date:
-                if not isinstance(data, str):
-                    raise TypeError(
-                        f"Expected string for deserializing to {klass_name}, got {type(data)}"
-                    )
-                return self.__deserialize_date(data)
-            elif klass == datetime.datetime:
-                if not isinstance(data, str):
-                    raise TypeError(
-                        f"Expected string for deserializing to {klass_name}, got {type(data)}"
-                    )
-                return self.__deserialize_datetime(data)
-
-        klass = self.models[klass_name]
-        if issubclass(klass, Enum):
-            return klass(data)
-        else:
-            if not isinstance(data, (dict, str)):
-                raise TypeError(
-                    f"Expected dict or string for deserializing to {klass_name}, got {type(data)}"
-                )
-            return self.__deserialize_model(data, klass)
+        """Deserialize ``dict``, ``list``, and ``str`` into an object."""
+        return self._deserializer.deserialize(data, klass_name)
 
     def call_api(
         self,
@@ -765,148 +678,9 @@ class ApiClient(ApiClientBase):
         else:
             return content_types[0]
 
-    def __deserialize_file(self, response: requests.Response) -> str:
-        """Deserialize the body to a file.
-
-        This method saves the response body in a file in a temporary folder,
-        using the file name from the ``Content-Disposition`` header if provided.
-
-        Parameters
-        ----------
-        response : requests.Response
-            The API response object to deserialize.
-        """
-        fd, path = tempfile.mkstemp(dir=self.configuration.temp_folder_path)
-        os.close(fd)
-        os.remove(path)
-
-        if "Content-Disposition" in response.headers:
-            filename_match = re.search(
-                r'filename=[\'"]?([^\'"\s]+)[\'"]?',
-                response.headers["Content-Disposition"],
-            )
-            if filename_match is not None:
-                filename = filename_match.group(1)
-                path = os.path.join(os.path.dirname(path), filename)
-
-        with open(path, "wb") as f:
-            f.write(response.content)
-
-        return path
-
     @staticmethod
     def __deserialize_primitive(
         data: PrimitiveType, klass: Callable[..., PrimitiveType]
     ) -> PrimitiveType:
-        """Deserialize to the primitive type.
-
-        Parameters
-        ----------
-        data : Union[str, int, float, bool, bytes]
-            Data to deserialize into the primitive type.
-        klass : Type
-            Type of target object for deserialization.
-        """
-        try:
-            return klass(data)
-        except UnicodeEncodeError:
-            return str(data)
-        except (ValueError, TypeError):
-            return data
-
-    @staticmethod
-    def __deserialize_object(value: object) -> object:
-        """Return an original value.
-
-        Parameters
-        ----------
-        value : object
-            Generic object that does not match any specific deserialization strategy.
-        """
-        return value
-
-    @staticmethod
-    def __deserialize_date(value: str) -> datetime.date:
-        """Deserialize string to ``datetime.date``.
-
-        Parameters
-        ----------
-        value : str
-            String representation of a date object in ISO 8601 format or otherwise.
-        """
-        try:
-            return parse(value).date()
-        except ValueError:
-            raise ApiException(
-                status_code=0,
-                reason_phrase=f"Failed to parse `{value}` as date object",
-            )
-
-    @staticmethod
-    def __deserialize_datetime(value: str) -> datetime.datetime:
-        """Deserialize string to ``datetime.datetime``.
-
-        Parameters
-        ----------
-        value : str
-            String representation of the ``datetime`` object in ISO 8601 format.
-        """
-        try:
-            return parse(value)
-        except ValueError:
-            raise ApiException(
-                status_code=0,
-                reason_phrase=f"Failed to parse `{value}` as datetime object",
-            )
-
-    def __deserialize_model(
-        self, data: Union[Dict, str], klass: Type[ModelBase]
-    ) -> Union[ModelBase, Dict, str]:
-        """Deserialize model representation to model.
-
-        Given a model type and the serialized data, deserialize into an instance of the model class.
-
-        Parameters
-        ----------
-        data : Union[Dict, str]
-            Serialized representation of the model object.
-        klass : ModelType
-            Type of the model to deserialize.
-        """
-        if not klass.swagger_types:
-            try:
-                klass.get_real_child_model(klass(), {})
-            except NotImplementedError:
-                return data
-            except BaseException:
-                pass
-
-        kwargs = {}
-        if klass.swagger_types is not None:
-            for attr, attr_type in klass.swagger_types.items():
-                if (
-                    data is not None
-                    and klass.attribute_map[attr] in data
-                    and isinstance(data, (list, dict))
-                ):
-                    value = data[klass.attribute_map[attr]]
-                    kwargs[attr] = self.__deserialize(value, attr_type)
-
-        instance = klass(**kwargs)
-
-        if (
-            isinstance(instance, dict)
-            and klass.swagger_types is not None
-            and isinstance(data, dict)
-        ):
-            for key, value in data.items():
-                if key not in klass.swagger_types:
-                    instance[key] = value
-        try:
-            klass_name = instance.get_real_child_model(data)  # type: ignore[arg-type]
-            if klass_name:
-                instance = self.__deserialize(data, klass_name)  # type: ignore[assignment]
-        except NotImplementedError:
-            pass
-
-        return instance
+        """Deserialize to the primitive type."""
+        return Deserializer._deserialize_primitive(data, klass)

--- a/src/ansys/openapi/common/_api_client.py
+++ b/src/ansys/openapi/common/_api_client.py
@@ -23,12 +23,13 @@
 import json
 import mimetypes
 import os
+import re
+import tempfile
 from enum import Enum
 from types import ModuleType
 from typing import (
     IO,
     Any,
-    Callable,
     Dict,
     Iterable,
     List,
@@ -43,13 +44,16 @@ from urllib.parse import quote
 
 import requests
 
-from ._base import ApiClientBase, DeserializedType, ModelBase, PrimitiveType, SerializedType
+from ._base import ApiClientBase, DeserializedType, ModelBase, SerializedType
 from ._deserializer import Deserializer
 from ._exceptions import ApiException
 from ._logger import logger
 from ._model_registry import ModelRegistry
 from ._serializer import Serializer
 from ._util import SessionConfiguration
+
+
+FILE_NAME_REGEX = re.compile(r'filename=[\'"]?([^\'"\s]+)[\'"]?')
 
 
 # noinspection DuplicatedCode
@@ -98,10 +102,7 @@ class ApiClient(ApiClientBase):
     ):
         self._model_registry = ModelRegistry()
         self._serializer = Serializer()
-        self._deserializer = Deserializer(
-            self._model_registry,
-            temp_folder_path=configuration.temp_folder_path,
-        )
+        self._deserializer = Deserializer(self._model_registry)
         self.api_url = api_url
         self.rest_client = session
         self.configuration = configuration
@@ -327,7 +328,15 @@ class ApiClient(ApiClientBase):
             return None
 
         if response_type == "file":
-            return self._deserializer.deserialize_response(response, response_type)
+            filename = None
+            if "Content-Disposition" in response.headers:
+                filename_match = re.search(
+                    FILE_NAME_REGEX,
+                    response.headers["Content-Disposition"],
+                )
+                if filename_match is not None:
+                    filename = filename_match.group(1)
+            return self._save_to_file(response.content, filename)
 
         if response_type == "str":
             data: SerializedType = response.text
@@ -337,11 +346,21 @@ class ApiClient(ApiClientBase):
             except ValueError:
                 data = response.content
 
-        return self.__deserialize(data, response_type)
+        return self._deserializer.deserialize(data, response_type)
 
-    def __deserialize(self, data: SerializedType, klass_name: str) -> DeserializedType:
-        """Deserialize ``dict``, ``list``, and ``str`` into an object."""
-        return self._deserializer.deserialize(data, klass_name)
+    def _save_to_file(self, content: bytes, filename: Optional[str] = None) -> str:
+        """Write response body bytes to a file and return its path."""
+        fd, path = tempfile.mkstemp(dir=self.configuration.temp_folder_path)
+        os.close(fd)
+        os.remove(path)
+
+        if filename:
+            path = os.path.join(os.path.dirname(path), filename)
+
+        with open(path, "wb") as f:
+            f.write(content)
+
+        return path
 
     def call_api(
         self,
@@ -666,10 +685,3 @@ class ApiClient(ApiClientBase):
             return "application/json"
         else:
             return content_types[0]
-
-    @staticmethod
-    def __deserialize_primitive(
-        data: PrimitiveType, klass: Callable[..., PrimitiveType]
-    ) -> PrimitiveType:
-        """Deserialize to the primitive type."""
-        return Deserializer._deserialize_primitive(data, klass)

--- a/src/ansys/openapi/common/_codec_types.py
+++ b/src/ansys/openapi/common/_codec_types.py
@@ -20,43 +20,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Provides a helper to create sessions for use with Ansys OpenAPI clients."""
+import datetime
+import re
 
-from importlib import metadata as metadata
-
-__version__ = metadata.version("ansys-openapi-common")
-
-from ._api_client import ApiClient
-from ._base import ApiBase, ApiClientBase, ModelBase, Unset, Unset_Type
-from ._deserializer import Deserializer
-from ._exceptions import (
-    ApiConnectionException,
-    ApiException,
-    AuthenticationWarning,
-    UndefinedObjectWarning,
-)
-from ._model_registry import ModelRegistry
-from ._oidc_config import OIDCConfiguration
-from ._session import ApiClientFactory, AuthenticationScheme, OIDCSessionBuilder
-from ._util import SessionConfiguration, generate_user_agent
-
-__all__ = [
-    "ApiClient",
-    "ApiClientFactory",
-    "AuthenticationScheme",
-    "SessionConfiguration",
-    "ApiException",
-    "ApiConnectionException",
-    "AuthenticationWarning",
-    "generate_user_agent",
-    "OIDCSessionBuilder",
-    "OIDCConfiguration",
-    "ApiBase",
-    "ApiClientBase",
-    "ModelBase",
-    "ModelRegistry",
-    "Deserializer",
-    "UndefinedObjectWarning",
-    "Unset",
-    "Unset_Type",
-]
+PRIMITIVE_TYPES = (float, bool, bytes, str, int)
+NATIVE_TYPES_MAPPING = {
+    "int": int,
+    "bytes": bytes,
+    "float": float,
+    "str": str,
+    "bool": bool,
+    "date": datetime.date,
+    "datetime": datetime.datetime,
+}
+LIST_MATCH_REGEX = re.compile(r"list\[(.*)]")
+DICT_MATCH_REGEX = re.compile(r"dict\(([^,]*), (.*)\)")

--- a/src/ansys/openapi/common/_deserializer.py
+++ b/src/ansys/openapi/common/_deserializer.py
@@ -1,0 +1,236 @@
+# Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import datetime
+from enum import Enum
+import os
+import re
+import tempfile
+from typing import Callable, Dict, Optional, Type, Union
+import warnings
+
+from dateutil.parser import parse
+import requests
+
+from ._base import DeserializedType, ModelBase, PrimitiveType, SerializedType
+from ._codec_types import (
+    DICT_MATCH_REGEX,
+    LIST_MATCH_REGEX,
+    NATIVE_TYPES_MAPPING,
+    PRIMITIVE_TYPES,
+)
+from ._exceptions import ApiException, UndefinedObjectWarning
+from ._model_registry import ModelRegistry
+
+
+class Deserializer:
+    """Deserializes wire-ready structures and HTTP responses into Python objects."""
+
+    def __init__(
+        self,
+        model_registry: ModelRegistry,
+        *,
+        temp_folder_path: Optional[str] = None,
+    ) -> None:
+        self._model_registry = model_registry
+        self._temp_folder_path = (
+            temp_folder_path if temp_folder_path is not None else tempfile.gettempdir()
+        )
+
+    def deserialize_response(
+        self, response: requests.Response, response_type: Optional[str]
+    ) -> DeserializedType:
+        """Deserialize an HTTP response into an object."""
+        if response_type is None:
+            return None
+
+        if response_type == "file":
+            return self._deserialize_file(response)
+
+        if response_type == "str":
+            data: SerializedType = response.text
+        else:
+            try:
+                data = response.json()
+            except ValueError:
+                data = response.content
+
+        return self.deserialize(data, response_type)
+
+    def deserialize(self, data: SerializedType, response_type: str) -> DeserializedType:
+        """Deserialize wire-ready data into an object."""
+        if data is None:
+            return None
+
+        if response_type == "object":
+            warnings.warn(
+                "Attempting to deserialize an object with no defined type. Returning "
+                "the raw data as a dictionary. Check your OpenAPI definition and ensure "
+                "all types are fully defined.",
+                UndefinedObjectWarning,
+            )
+            return data
+
+        list_match = LIST_MATCH_REGEX.match(response_type)
+        if list_match is not None:
+            if not isinstance(data, list):
+                raise TypeError(
+                    f"Expected list for deserializing to {response_type}, got {type(data)}"
+                )
+            sub_kls = list_match.group(1)
+            return [self.deserialize(sub_data, sub_kls) for sub_data in data]
+
+        dict_match = DICT_MATCH_REGEX.match(response_type)
+        if dict_match is not None:
+            if not isinstance(data, dict):
+                raise TypeError(
+                    f"Expected dict for deserializing to {response_type}, got {type(data)}"
+                )
+            sub_kls = dict_match.group(2)
+            return {k: self.deserialize(v, sub_kls) for k, v in data.items()}
+
+        if response_type in NATIVE_TYPES_MAPPING:
+            klass = NATIVE_TYPES_MAPPING[response_type]
+            if klass in PRIMITIVE_TYPES:
+                if not isinstance(data, (str, int, float, bool, bytes)):
+                    raise TypeError(
+                        f"Expected primitive type for deserializing to {response_type}, got {type(data)}"
+                    )
+                return self._deserialize_primitive(data, klass)
+            elif klass == datetime.date:
+                if not isinstance(data, str):
+                    raise TypeError(
+                        f"Expected string for deserializing to {response_type}, got {type(data)}"
+                    )
+                return self._deserialize_date(data)
+            elif klass == datetime.datetime:
+                if not isinstance(data, str):
+                    raise TypeError(
+                        f"Expected string for deserializing to {response_type}, got {type(data)}"
+                    )
+                return self._deserialize_datetime(data)
+
+        klass = self._model_registry.get(response_type)
+        if issubclass(klass, Enum):
+            return klass(data)
+        else:
+            if not isinstance(data, (dict, str)):
+                raise TypeError(
+                    f"Expected dict or string for deserializing to {response_type}, got {type(data)}"
+                )
+            return self._deserialize_model(data, klass)
+
+    def _deserialize_file(self, response: requests.Response) -> str:
+        """Deserialize the body to a file."""
+        fd, path = tempfile.mkstemp(dir=self._temp_folder_path)
+        os.close(fd)
+        os.remove(path)
+
+        if "Content-Disposition" in response.headers:
+            filename_match = re.search(
+                r'filename=[\'"]?([^\'"\s]+)[\'"]?',
+                response.headers["Content-Disposition"],
+            )
+            if filename_match is not None:
+                filename = filename_match.group(1)
+                path = os.path.join(os.path.dirname(path), filename)
+
+        with open(path, "wb") as f:
+            f.write(response.content)
+
+        return path
+
+    @staticmethod
+    def _deserialize_primitive(
+        data: PrimitiveType, klass: Callable[..., PrimitiveType]
+    ) -> PrimitiveType:
+        """Deserialize to the primitive type."""
+        try:
+            return klass(data)
+        except UnicodeEncodeError:
+            return str(data)
+        except (ValueError, TypeError):
+            return data
+
+    @staticmethod
+    def _deserialize_date(value: str) -> datetime.date:
+        """Deserialize string to ``datetime.date``."""
+        try:
+            return parse(value).date()
+        except ValueError:
+            raise ApiException(
+                status_code=0,
+                reason_phrase=f"Failed to parse `{value}` as date object",
+            )
+
+    @staticmethod
+    def _deserialize_datetime(value: str) -> datetime.datetime:
+        """Deserialize string to ``datetime.datetime``."""
+        try:
+            return parse(value)
+        except ValueError:
+            raise ApiException(
+                status_code=0,
+                reason_phrase=f"Failed to parse `{value}` as datetime object",
+            )
+
+    def _deserialize_model(
+        self, data: Union[Dict, str], klass: Type[ModelBase]
+    ) -> Union[ModelBase, Dict, str]:
+        """Deserialize model representation to model."""
+        if not klass.swagger_types:
+            try:
+                klass.get_real_child_model(klass(), {})
+            except NotImplementedError:
+                return data
+            except BaseException:
+                pass
+
+        kwargs = {}
+        if klass.swagger_types is not None:
+            for attr, attr_type in klass.swagger_types.items():
+                if (
+                    data is not None
+                    and klass.attribute_map[attr] in data
+                    and isinstance(data, (list, dict))
+                ):
+                    value = data[klass.attribute_map[attr]]
+                    kwargs[attr] = self.deserialize(value, attr_type)
+
+        instance = klass(**kwargs)
+
+        if (
+            isinstance(instance, dict)
+            and klass.swagger_types is not None
+            and isinstance(data, dict)
+        ):
+            for key, value in data.items():
+                if key not in klass.swagger_types:
+                    instance[key] = value
+        try:
+            klass_name = instance.get_real_child_model(data)  # type: ignore[arg-type]
+            if klass_name:
+                instance = self.deserialize(data, klass_name)  # type: ignore[assignment]
+        except NotImplementedError:
+            pass
+
+        return instance

--- a/src/ansys/openapi/common/_deserializer.py
+++ b/src/ansys/openapi/common/_deserializer.py
@@ -22,14 +22,10 @@
 
 import datetime
 from enum import Enum
-import os
-import re
-import tempfile
-from typing import Callable, Dict, Optional, Type, Union
+from typing import Callable, Dict, Type, Union
 import warnings
 
 from dateutil.parser import parse
-import requests
 
 from ._base import DeserializedType, ModelBase, PrimitiveType, SerializedType
 from ._codec_types import (
@@ -43,38 +39,10 @@ from ._model_registry import ModelRegistry
 
 
 class Deserializer:
-    """Deserializes wire-ready structures and HTTP responses into Python objects."""
+    """Deserializes wire-ready data structures into Python objects."""
 
-    def __init__(
-        self,
-        model_registry: ModelRegistry,
-        *,
-        temp_folder_path: Optional[str] = None,
-    ) -> None:
+    def __init__(self, model_registry: ModelRegistry) -> None:
         self._model_registry = model_registry
-        self._temp_folder_path = (
-            temp_folder_path if temp_folder_path is not None else tempfile.gettempdir()
-        )
-
-    def deserialize_response(
-        self, response: requests.Response, response_type: Optional[str]
-    ) -> DeserializedType:
-        """Deserialize an HTTP response into an object."""
-        if response_type is None:
-            return None
-
-        if response_type == "file":
-            return self._deserialize_file(response)
-
-        if response_type == "str":
-            data: SerializedType = response.text
-        else:
-            try:
-                data = response.json()
-            except ValueError:
-                data = response.content
-
-        return self.deserialize(data, response_type)
 
     def deserialize(self, data: SerializedType, response_type: str) -> DeserializedType:
         """Deserialize wire-ready data into an object."""
@@ -138,26 +106,6 @@ class Deserializer:
                     f"Expected dict or string for deserializing to {response_type}, got {type(data)}"
                 )
             return self._deserialize_model(data, klass)
-
-    def _deserialize_file(self, response: requests.Response) -> str:
-        """Deserialize the body to a file."""
-        fd, path = tempfile.mkstemp(dir=self._temp_folder_path)
-        os.close(fd)
-        os.remove(path)
-
-        if "Content-Disposition" in response.headers:
-            filename_match = re.search(
-                r'filename=[\'"]?([^\'"\s]+)[\'"]?',
-                response.headers["Content-Disposition"],
-            )
-            if filename_match is not None:
-                filename = filename_match.group(1)
-                path = os.path.join(os.path.dirname(path), filename)
-
-        with open(path, "wb") as f:
-            f.write(response.content)
-
-        return path
 
     @staticmethod
     def _deserialize_primitive(

--- a/src/ansys/openapi/common/_model_registry.py
+++ b/src/ansys/openapi/common/_model_registry.py
@@ -1,0 +1,59 @@
+# Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from enum import Enum
+from types import ModuleType
+from typing import Dict, Type, Union
+
+from ._base import ModelBase
+
+
+class ModelRegistry:
+    """Maps OpenAPI model and enum type names to their Python classes."""
+
+    def __init__(self) -> None:
+        self._models: Dict[str, Union[Type[ModelBase], Type[Enum]]] = {}
+
+    @property
+    def models(self) -> Dict[str, Union[Type[ModelBase], Type[Enum]]]:
+        """Registered model and enum classes keyed by their OpenAPI type name."""
+        return self._models
+
+    def register(self, name: str, klass: Union[Type[ModelBase], Type[Enum]]) -> None:
+        """Register a single model or enum class."""
+        self._models[name] = klass
+
+    def register_module(self, models: ModuleType) -> None:
+        """Register all :class:`ModelBase` and :class:`Enum` classes from a generated models module."""
+        for name, value in models.__dict__.items():
+            if isinstance(value, type) and (
+                issubclass(value, ModelBase) or issubclass(value, Enum)
+            ):
+                self._models[name] = value
+
+    def get(self, name: str) -> Union[Type[ModelBase], Type[Enum]]:
+        """Return the class registered under ``name``."""
+        return self._models[name]
+
+    def __contains__(self, name: str) -> bool:
+        """Return whether ``name`` is registered."""
+        return name in self._models

--- a/src/ansys/openapi/common/_serializer.py
+++ b/src/ansys/openapi/common/_serializer.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import datetime
+from enum import Enum
+from typing import Any
+
+from ._base import Unset
+from ._codec_types import PRIMITIVE_TYPES
+
+
+class Serializer:
+    """Serializes Python objects into wire-ready structures for OpenAPI clients."""
+
+    def serialize(self, obj: Any) -> Any:
+        """Build a JSON-serializable representation of ``obj`` for transmission to the API."""
+        if obj is None:
+            return None
+        elif isinstance(obj, PRIMITIVE_TYPES):
+            return obj
+        elif isinstance(obj, list):
+            return [self.serialize(sub_obj) for sub_obj in obj]
+        elif isinstance(obj, tuple):
+            return tuple(self.serialize(sub_obj) for sub_obj in obj)
+        elif isinstance(obj, (datetime.datetime, datetime.date)):
+            return obj.isoformat()
+        elif isinstance(obj, Enum):
+            return obj.value
+
+        if isinstance(obj, dict):
+            obj_dict = obj
+        else:
+            obj_dict = {
+                obj.attribute_map[attr]: getattr(obj, attr)
+                for attr in obj.swagger_types
+                if getattr(obj, attr) is not Unset
+            }
+
+        return {key: self.serialize(val) for key, val in obj_dict.items()}

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -41,7 +41,6 @@ from ansys.openapi.common import (
     ApiClient,
     ApiException,
     SessionConfiguration,
-    UndefinedObjectWarning,
 )
 
 from .models import ExampleException
@@ -271,263 +270,6 @@ class TestSerialization:
         assert serialized_enum == "Good"
 
 
-class TestDeserialization:
-    _test_value_list = ["foo", int(2), 2.0, True]
-    _test_value_types = [str, int, float, bool]
-
-    @pytest.fixture(autouse=True)
-    def _blank_client(self, blank_client):
-        self._client = blank_client
-
-    def test_deserialize_none(self):
-        assert self._client._deserializer.deserialize(None, "") is None
-
-    @pytest.mark.parametrize(
-        ("value", "type_"), (("foo", str), (int(2), int), (2.0, float), (True, bool))
-    )
-    def test_deserialize_primitive(self, value, type_):
-        type_ref = type_.__name__
-        deserialized_primitive = self._client._deserializer.deserialize(value, type_ref)
-        assert isinstance(deserialized_primitive, type_)
-        assert deserialized_primitive == value
-
-    @pytest.mark.parametrize(("target_type", "expected_result"), ((int, int(3)), (str, "3.1")))
-    def test_deserialize_float_casts(self, target_type, expected_result):
-        test_float = 3.1
-        deserialized_object = self._client._deserializer.deserialize(
-            test_float, target_type.__name__
-        )
-        assert isinstance(deserialized_object, target_type)
-        assert deserialized_object == expected_result
-
-    def test_deserialize_bytes(self):
-        source_bytes = b"\x66\x6f\x6f"
-        deserialized_bytes = self._client._deserializer.deserialize(source_bytes, "bytes")
-        assert isinstance(deserialized_bytes, bytes)
-        assert deserialized_bytes == source_bytes
-
-    def test_deserialize_list(self):
-        source_list = ["Look", "another", "list"]
-        deserialized_list = self._client._deserializer.deserialize(source_list, "list[str]")
-        assert isinstance(deserialized_list, list)
-        assert deserialized_list == source_list
-
-    def test_deserialize_dict(self):
-        source_dict = {1: "one", 2: "two", 3: "three"}
-        deserialized_dict = self._client._deserializer.deserialize(source_dict, "dict(int, str)")
-        assert isinstance(deserialized_dict, dict)
-        assert deserialized_dict == source_dict
-
-    def test_deserialize_dict_casts_ints(self):
-        source_dict = {"one": 1.0, "two": 2.0, "three": 3.1}
-        deserialized_dict = self._client._deserializer.deserialize(source_dict, "dict(str, int)")
-        assert isinstance(deserialized_dict, dict)
-        for key, val in source_dict.items():
-            assert key in deserialized_dict
-            assert deserialized_dict[key] == int(val)
-
-    def test_deserialize_date(self):
-        source_date = datetime.date(2371, 4, 26)
-        date_string = source_date.isoformat()
-        type_ref = "date"
-        deserialized_date = self._client._deserializer.deserialize(date_string, type_ref)
-        assert isinstance(deserialized_date, datetime.date)
-        assert deserialized_date == source_date
-
-    @pytest.mark.parametrize("object_type", ("date", "datetime"))
-    def test_invalid_date_like_throws(self, object_type):
-        invalid_date = "NOT-A-DATE"
-        with pytest.raises(ApiException) as exception_info:
-            _ = self._client._deserializer.deserialize(invalid_date, object_type)
-        assert invalid_date in exception_info.value.reason_phrase
-        assert f"{object_type} object" in exception_info.value.reason_phrase
-
-    def test_deserialize_datetime(self):
-        source_datetime = datetime.datetime(2371, 4, 26, 4, 39, 21)
-        datetime_string = source_datetime.isoformat()
-        type_ref = "datetime"
-        deserialized_datetime = self._client._deserializer.deserialize(datetime_string, type_ref)
-        assert isinstance(deserialized_datetime, datetime.datetime)
-        assert deserialized_datetime == source_datetime
-
-    def test_deserialize_model(self):
-        from . import models
-
-        self._client.setup_client(models)
-
-        model_instance = models.ExampleModel("foo", 3, False, ["It's", "a", "list"])
-        model_dict = {
-            "Boolean": False,
-            "Integer": 3,
-            "ListOfStrings": ["It's", "a", "list"],
-            "String": "foo",
-        }
-        type_ref = "ExampleModel"
-        deserialized_model = self._client._deserializer.deserialize(model_dict, type_ref)
-        assert isinstance(deserialized_model, models.ExampleModel)
-        assert deserialized_model == model_instance
-
-    @pytest.mark.parametrize(
-        "value", [[("Boolean", False)], (("Boolean", False),), 1, 1.0, True, b"foo"]
-    )
-    def test_deserialize_model_with_incorrect_value_type_raises_type_error(self, value):
-        from . import models
-
-        self._client.setup_client(models)
-
-        type_ref = "ExampleModel"
-        with pytest.raises(TypeError) as exception_info:
-            _ = self._client._deserializer.deserialize(value, type_ref)
-        assert "dict or string" in str(exception_info.value)
-
-    def test_deserialize_model_with_discriminator(self):
-        from . import models
-
-        self._client.setup_client(models)
-
-        model_instance = models.ExampleModel("foo", 3, False, ["It's", "a", "list"])
-        model_dict = {
-            "Boolean": False,
-            "Integer": 3,
-            "ListOfStrings": ["It's", "a", "list"],
-            "String": "foo",
-            "modelType": "ExampleModel",
-        }
-        type_ref = "ExampleBaseModel"
-        deserialized_model = self._client._deserializer.deserialize(model_dict, type_ref)
-        assert isinstance(deserialized_model, models.ExampleModel)
-        assert deserialized_model == model_instance
-
-    def test_deserialize_enum_model(self):
-        from . import models
-
-        self._client.setup_client(models)
-        model_instance = models.ExampleModelWithEnum().GOOD
-        model_value = "Good"
-        type_ref = "ExampleModelWithEnum"
-        serialized_model = self._client._deserializer.deserialize(model_value, type_ref)
-        assert serialized_model == model_instance
-
-    def test_deserialize_enum(self):
-        from . import models
-
-        self._client.setup_client(models)
-        value = "Good"
-        type_ref = "ExampleEnum"
-        serialized_enum = self._client._deserializer.deserialize(value, type_ref)
-        assert isinstance(serialized_enum, models.ExampleEnum)
-        assert serialized_enum == models.ExampleEnum.GOOD
-
-    def test_deserialize_int_enum(self):
-        from . import models
-
-        self._client.setup_client(models)
-        value = 200
-        type_ref = "ExampleIntEnum"
-        serialized_enum = self._client._deserializer.deserialize(value, type_ref)
-        assert isinstance(serialized_enum, models.ExampleIntEnum)
-        assert serialized_enum == models.ExampleIntEnum._200
-
-    @pytest.mark.parametrize(
-        ["value", "target_enum", "expected_error_msg"],
-        [
-            ("200", "ExampleIntEnum", "'200' is not a valid ExampleIntEnum"),
-            (4.5, "ExampleIntEnum", "4.5 is not a valid ExampleIntEnum"),
-            (4, "ExampleIntEnum", "4 is not a valid ExampleIntEnum"),
-            ("SomeValue", "ExampleEnum", "'SomeValue' is not a valid ExampleEnum"),
-            (4.5, "ExampleEnum", "4.5 is not a valid ExampleEnum"),
-            (4, "ExampleEnum", "4 is not a valid ExampleEnum"),
-        ],
-    )
-    def test_deserialize_enums_raises_helpful_message_on_wrong_value(
-        self, value, target_enum, expected_error_msg
-    ):
-        from . import models
-
-        self._client.setup_client(models)
-        with pytest.raises(ValueError, match=expected_error_msg):
-            _ = self._client._deserializer.deserialize(value, target_enum)
-
-    @pytest.mark.parametrize(
-        ("data", "target_type"),
-        (
-            (5.0, bytes),
-            ("foo", int),
-            ("foo", float),
-            ("foo", bytes),
-            (b"\x01", int),
-            (b"\x01", float),
-        ),
-    )
-    def test_deserialize_primitive_of_wrong_type_does_nothing(self, data, target_type):
-        output = self._client._deserializer.deserialize(data, target_type.__name__)
-        assert isinstance(output, type(data))
-        assert output == data
-
-    def test_deserialize_undefined_object_returns_dict_and_warns(self):
-        data = {"foo": "bar", "baz": [1, 2, 3]}
-        with pytest.warns(
-            UndefinedObjectWarning,
-            match="Attempting to deserialize an object with no defined type",
-        ):
-            output = self._client._deserializer.deserialize(data, "object")
-        assert output == data
-
-    @pytest.mark.parametrize(
-        ("type_name, value"),
-        [
-            ("list[str]", ("foo")),
-            ("list[str]", "foo"),
-            ("list[str]", 1),
-            ("list[str]", 1.0),
-            ("list[str]", b"foo"),
-            ("list[str]", True),
-            ("list[str]", datetime.date.today()),
-            ("dict(str, int)", ["foo"]),
-            ("dict(str, int)", ("foo")),
-            ("dict(str, int)", 1),
-            ("dict(str, int)", 1.0),
-            ("dict(str, int)", b"foo"),
-            ("dict(str, int)", True),
-            ("dict(str, int)", datetime.date.today()),
-            ("str", ["foo"]),
-            ("str", ("foo",)),
-            ("str", datetime.date.today()),
-            ("int", [1]),
-            ("int", (1,)),
-            ("int", datetime.date.today()),
-            ("float", [1.0]),
-            ("float", (1.0,)),
-            ("float", datetime.date.today()),
-            ("bool", [True]),
-            ("bool", (True,)),
-            ("bool", datetime.date.today()),
-            ("bytes", [b"foo"]),
-            ("bytes", (b"foo",)),
-            ("bytes", datetime.date.today()),
-            ("datetime", ["2023-01-01T00:00:00Z"]),
-            ("datetime", ("2023-01-01T00:00:00Z",)),
-            ("datetime", datetime.datetime.now()),
-            ("datetime", 1),
-            ("datetime", 1.0),
-            ("datetime", True),
-            ("datetime", b"2023-01-01T00:00:00Z"),
-            ("date", ["2023-01-01"]),
-            ("date", ("2023-01-01",)),
-            ("date", datetime.date.today()),
-            ("date", 1),
-            ("date", 1.0),
-            ("date", True),
-            ("date", b"2023-01-01"),
-        ],
-    )
-    def test_deserialize_wrong_type_raises_type_error_simple(self, type_name, value):
-        with pytest.raises(TypeError) as e:
-            _ = self._client._deserializer.deserialize(value, type_name)
-        assert type_name in str(e.value)
-        assert str(type(value)) in str(e.value)
-
-
 class TestResponseParsing:
     from requests.adapters import HTTPAdapter
 
@@ -591,6 +333,22 @@ class TestResponseParsing:
         _ = self._client.deserialize(response, "dict")
         deserialize_mock.assert_called()
         deserialize_mock.assert_called_once_with(data, "dict")
+
+    def test_json_response_deserializes_to_model(self):
+        from . import models
+
+        self._client.setup_client(models)
+        api_response = {
+            "String": "foo",
+            "Integer": 3,
+            "ListOfStrings": ["It's", "a", "list"],
+            "Boolean": False,
+        }
+        expected = models.ExampleModel("foo", 3, False, ["It's", "a", "list"])
+        response = self.create_response(api_response)
+        result = self._client.deserialize(response, "ExampleModel")
+        assert isinstance(result, models.ExampleModel)
+        assert result == expected
 
     def test_text_parsed_as_text(self, mocker):
         data = "This is some data this is definitely not json, it should be rendered as a string"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -280,45 +280,47 @@ class TestDeserialization:
         self._client = blank_client
 
     def test_deserialize_none(self):
-        assert self._client._ApiClient__deserialize(None, "") is None
+        assert self._client._deserializer.deserialize(None, "") is None
 
     @pytest.mark.parametrize(
         ("value", "type_"), (("foo", str), (int(2), int), (2.0, float), (True, bool))
     )
     def test_deserialize_primitive(self, value, type_):
         type_ref = type_.__name__
-        deserialized_primitive = self._client._ApiClient__deserialize(value, type_ref)
+        deserialized_primitive = self._client._deserializer.deserialize(value, type_ref)
         assert isinstance(deserialized_primitive, type_)
         assert deserialized_primitive == value
 
     @pytest.mark.parametrize(("target_type", "expected_result"), ((int, int(3)), (str, "3.1")))
     def test_deserialize_float_casts(self, target_type, expected_result):
         test_float = 3.1
-        deserialized_object = self._client._ApiClient__deserialize(test_float, target_type.__name__)
+        deserialized_object = self._client._deserializer.deserialize(
+            test_float, target_type.__name__
+        )
         assert isinstance(deserialized_object, target_type)
         assert deserialized_object == expected_result
 
     def test_deserialize_bytes(self):
         source_bytes = b"\x66\x6f\x6f"
-        deserialized_bytes = self._client._ApiClient__deserialize(source_bytes, "bytes")
+        deserialized_bytes = self._client._deserializer.deserialize(source_bytes, "bytes")
         assert isinstance(deserialized_bytes, bytes)
         assert deserialized_bytes == source_bytes
 
     def test_deserialize_list(self):
         source_list = ["Look", "another", "list"]
-        deserialized_list = self._client._ApiClient__deserialize(source_list, "list[str]")
+        deserialized_list = self._client._deserializer.deserialize(source_list, "list[str]")
         assert isinstance(deserialized_list, list)
         assert deserialized_list == source_list
 
     def test_deserialize_dict(self):
         source_dict = {1: "one", 2: "two", 3: "three"}
-        deserialized_dict = self._client._ApiClient__deserialize(source_dict, "dict(int, str)")
+        deserialized_dict = self._client._deserializer.deserialize(source_dict, "dict(int, str)")
         assert isinstance(deserialized_dict, dict)
         assert deserialized_dict == source_dict
 
     def test_deserialize_dict_casts_ints(self):
         source_dict = {"one": 1.0, "two": 2.0, "three": 3.1}
-        deserialized_dict = self._client._ApiClient__deserialize(source_dict, "dict(str, int)")
+        deserialized_dict = self._client._deserializer.deserialize(source_dict, "dict(str, int)")
         assert isinstance(deserialized_dict, dict)
         for key, val in source_dict.items():
             assert key in deserialized_dict
@@ -328,7 +330,7 @@ class TestDeserialization:
         source_date = datetime.date(2371, 4, 26)
         date_string = source_date.isoformat()
         type_ref = "date"
-        deserialized_date = self._client._ApiClient__deserialize(date_string, type_ref)
+        deserialized_date = self._client._deserializer.deserialize(date_string, type_ref)
         assert isinstance(deserialized_date, datetime.date)
         assert deserialized_date == source_date
 
@@ -336,7 +338,7 @@ class TestDeserialization:
     def test_invalid_date_like_throws(self, object_type):
         invalid_date = "NOT-A-DATE"
         with pytest.raises(ApiException) as exception_info:
-            _ = self._client._ApiClient__deserialize(invalid_date, object_type)
+            _ = self._client._deserializer.deserialize(invalid_date, object_type)
         assert invalid_date in exception_info.value.reason_phrase
         assert f"{object_type} object" in exception_info.value.reason_phrase
 
@@ -344,7 +346,7 @@ class TestDeserialization:
         source_datetime = datetime.datetime(2371, 4, 26, 4, 39, 21)
         datetime_string = source_datetime.isoformat()
         type_ref = "datetime"
-        deserialized_datetime = self._client._ApiClient__deserialize(datetime_string, type_ref)
+        deserialized_datetime = self._client._deserializer.deserialize(datetime_string, type_ref)
         assert isinstance(deserialized_datetime, datetime.datetime)
         assert deserialized_datetime == source_datetime
 
@@ -361,7 +363,7 @@ class TestDeserialization:
             "String": "foo",
         }
         type_ref = "ExampleModel"
-        deserialized_model = self._client._ApiClient__deserialize(model_dict, type_ref)
+        deserialized_model = self._client._deserializer.deserialize(model_dict, type_ref)
         assert isinstance(deserialized_model, models.ExampleModel)
         assert deserialized_model == model_instance
 
@@ -375,7 +377,7 @@ class TestDeserialization:
 
         type_ref = "ExampleModel"
         with pytest.raises(TypeError) as exception_info:
-            _ = self._client._ApiClient__deserialize(value, type_ref)
+            _ = self._client._deserializer.deserialize(value, type_ref)
         assert "dict or string" in str(exception_info.value)
 
     def test_deserialize_model_with_discriminator(self):
@@ -392,7 +394,7 @@ class TestDeserialization:
             "modelType": "ExampleModel",
         }
         type_ref = "ExampleBaseModel"
-        deserialized_model = self._client._ApiClient__deserialize(model_dict, type_ref)
+        deserialized_model = self._client._deserializer.deserialize(model_dict, type_ref)
         assert isinstance(deserialized_model, models.ExampleModel)
         assert deserialized_model == model_instance
 
@@ -403,7 +405,7 @@ class TestDeserialization:
         model_instance = models.ExampleModelWithEnum().GOOD
         model_value = "Good"
         type_ref = "ExampleModelWithEnum"
-        serialized_model = self._client._ApiClient__deserialize(model_value, type_ref)
+        serialized_model = self._client._deserializer.deserialize(model_value, type_ref)
         assert serialized_model == model_instance
 
     def test_deserialize_enum(self):
@@ -412,7 +414,7 @@ class TestDeserialization:
         self._client.setup_client(models)
         value = "Good"
         type_ref = "ExampleEnum"
-        serialized_enum = self._client._ApiClient__deserialize(value, type_ref)
+        serialized_enum = self._client._deserializer.deserialize(value, type_ref)
         assert isinstance(serialized_enum, models.ExampleEnum)
         assert serialized_enum == models.ExampleEnum.GOOD
 
@@ -422,7 +424,7 @@ class TestDeserialization:
         self._client.setup_client(models)
         value = 200
         type_ref = "ExampleIntEnum"
-        serialized_enum = self._client._ApiClient__deserialize(value, type_ref)
+        serialized_enum = self._client._deserializer.deserialize(value, type_ref)
         assert isinstance(serialized_enum, models.ExampleIntEnum)
         assert serialized_enum == models.ExampleIntEnum._200
 
@@ -444,7 +446,7 @@ class TestDeserialization:
 
         self._client.setup_client(models)
         with pytest.raises(ValueError, match=expected_error_msg):
-            _ = self._client._ApiClient__deserialize(value, target_enum)
+            _ = self._client._deserializer.deserialize(value, target_enum)
 
     @pytest.mark.parametrize(
         ("data", "target_type"),
@@ -458,7 +460,7 @@ class TestDeserialization:
         ),
     )
     def test_deserialize_primitive_of_wrong_type_does_nothing(self, data, target_type):
-        output = self._client._ApiClient__deserialize_primitive(data, target_type)
+        output = self._client._deserializer.deserialize(data, target_type.__name__)
         assert isinstance(output, type(data))
         assert output == data
 
@@ -468,7 +470,7 @@ class TestDeserialization:
             UndefinedObjectWarning,
             match="Attempting to deserialize an object with no defined type",
         ):
-            output = self._client._ApiClient__deserialize(data, "object")
+            output = self._client._deserializer.deserialize(data, "object")
         assert output == data
 
     @pytest.mark.parametrize(
@@ -521,7 +523,7 @@ class TestDeserialization:
     )
     def test_deserialize_wrong_type_raises_type_error_simple(self, type_name, value):
         with pytest.raises(TypeError) as e:
-            _ = self._client._ApiClient__deserialize(value, type_name)
+            _ = self._client._deserializer.deserialize(value, type_name)
         assert type_name in str(e.value)
         assert str(type(value)) in str(e.value)
 
@@ -576,15 +578,15 @@ class TestResponseParsing:
     def test_response_is_not_deserialized_if_type_is_none(self, mocker):
         data = {"one": 1, "two": 2, "three": 3}
         response = self.create_response(data)
-        _deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
+        deserialize_mock = mocker.patch.object(self._client._deserializer, "deserialize")
         result = self._client.deserialize(response, None)
         assert result is None
-        _deserialize_mock.assert_not_called()
+        deserialize_mock.assert_not_called()
 
     def test_json_parsed_as_json(self, mocker):
         data = {"one": 1, "two": 2, "three": 3}
         response = self.create_response(data)
-        deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
+        deserialize_mock = mocker.patch.object(self._client._deserializer, "deserialize")
         deserialize_mock.return_value = True
         _ = self._client.deserialize(response, "dict")
         deserialize_mock.assert_called()
@@ -593,7 +595,7 @@ class TestResponseParsing:
     def test_text_parsed_as_text(self, mocker):
         data = "This is some data this is definitely not json, it should be rendered as a string"
         response = self.create_response(text=data, content_type="text/plain")
-        deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
+        deserialize_mock = mocker.patch.object(self._client._deserializer, "deserialize")
         deserialize_mock.return_value = True
         _ = self._client.deserialize(response, "str")
         deserialize_mock.assert_called()
@@ -602,7 +604,7 @@ class TestResponseParsing:
     def test_deserialize_json_as_string_returns_string(self, mocker):
         data = json.dumps({"foo": "bar", "baz": [1, 2, 3]})
         response = self.create_response(text=data, content_type="text/plain")
-        deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
+        deserialize_mock = mocker.patch.object(self._client._deserializer, "deserialize")
         deserialize_mock.return_value = True
         _ = self._client.deserialize(response, "str")
         deserialize_mock.assert_called()
@@ -615,7 +617,7 @@ class TestResponseParsing:
         response = self.create_response(content=data, content_type="application/octet-stream")
         if not provide_content_type:
             response.headers.pop("Content-Type")
-        deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
+        deserialize_mock = mocker.patch.object(self._client._deserializer, "deserialize")
         deserialize_mock.return_value = True
         _ = self._client.deserialize(response, "bytes")
         deserialize_mock.assert_called()
@@ -629,7 +631,7 @@ class TestResponseParsing:
             <body>Don't forget me this weekend!</body>
         </note>"""
         response = self.create_response(text=data, content_type="application/xml")
-        deserialize_mock = mocker.patch.object(ApiClient, "_ApiClient__deserialize")
+        deserialize_mock = mocker.patch.object(self._client._deserializer, "deserialize")
         deserialize_mock.return_value = True
         _ = self._client.deserialize(response, "str")
         deserialize_mock.assert_called()

--- a/tests/test_deserializer.py
+++ b/tests/test_deserializer.py
@@ -1,0 +1,370 @@
+# Copyright (C) 2022 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import datetime
+
+import pytest
+
+from ansys.openapi.common._base import ModelBase
+from ansys.openapi.common._deserializer import Deserializer
+from ansys.openapi.common._exceptions import ApiException, UndefinedObjectWarning
+from ansys.openapi.common._model_registry import ModelRegistry
+
+
+class DictBackedModel(dict, ModelBase):
+    swagger_types = {"label": "str"}
+    attribute_map = {"label": "Label"}
+
+    def __init__(self, label=None):
+        super().__init__()
+        self._label = label
+
+    @property
+    def label(self):
+        return self._label
+
+    @label.setter
+    def label(self, label):
+        self._label = label
+
+
+class EmptyModelReturningRawData(ModelBase):
+    swagger_types = {}
+    attribute_map = {}
+
+    def __init__(self):
+        pass
+
+
+class EmptyModelWithProbeError(ModelBase):
+    swagger_types = {}
+    attribute_map = {}
+
+    def __init__(self):
+        pass
+
+    def get_real_child_model(self, data):
+        if data == {}:
+            raise ValueError("probe failed")
+        raise NotImplementedError
+
+
+class ModelWithoutDiscriminator(ModelBase):
+    swagger_types = {"name": "str"}
+    attribute_map = {"name": "Name"}
+
+    def __init__(self, name=None):
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, name):
+        self._name = name
+
+    def get_real_child_model(self, data):
+        raise NotImplementedError
+
+
+@pytest.fixture
+def model_registry():
+    from . import models
+
+    registry = ModelRegistry()
+    registry.register_module(models)
+    registry.register("DictBackedModel", DictBackedModel)
+    registry.register("EmptyModelReturningRawData", EmptyModelReturningRawData)
+    registry.register("EmptyModelWithProbeError", EmptyModelWithProbeError)
+    registry.register("ModelWithoutDiscriminator", ModelWithoutDiscriminator)
+    return registry
+
+
+@pytest.fixture
+def deserializer(model_registry):
+    return Deserializer(model_registry)
+
+
+class TestDeserializeBasics:
+    def test_none_data_returns_none(self, deserializer):
+        assert deserializer.deserialize(None, "str") is None
+
+    def test_undefined_object_returns_dict_and_warns(self, deserializer):
+        data = {"foo": "bar", "baz": [1, 2, 3]}
+        with pytest.warns(
+            UndefinedObjectWarning,
+            match="Attempting to deserialize an object with no defined type",
+        ):
+            output = deserializer.deserialize(data, "object")
+        assert output == data
+
+
+class TestDeserializePrimitives:
+    @pytest.mark.parametrize(
+        ("value", "type_"), (("foo", str), (int(2), int), (2.0, float), (True, bool))
+    )
+    def test_primitive_round_trip(self, deserializer, value, type_):
+        type_ref = type_.__name__
+        result = deserializer.deserialize(value, type_ref)
+        assert isinstance(result, type_)
+        assert result == value
+
+    def test_bytes_round_trip(self, deserializer):
+        source_bytes = b"\x66\x6f\x6f"
+        result = deserializer.deserialize(source_bytes, "bytes")
+        assert isinstance(result, bytes)
+        assert result == source_bytes
+
+    @pytest.mark.parametrize(("target_type", "expected_result"), ((int, int(3)), (str, "3.1")))
+    def test_float_casts(self, deserializer, target_type, expected_result):
+        result = deserializer.deserialize(3.1, target_type.__name__)
+        assert isinstance(result, target_type)
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
+        ("data", "target_type"),
+        (
+            (5.0, bytes),
+            ("foo", int),
+            ("foo", float),
+            ("foo", bytes),
+            (b"\x01", int),
+            (b"\x01", float),
+        ),
+    )
+    def test_invalid_primitive_cast_returns_original_data(self, deserializer, data, target_type):
+        result = deserializer.deserialize(data, target_type.__name__)
+        assert isinstance(result, type(data))
+        assert result == data
+
+    def test_primitive_unicode_encode_error_returns_string(self):
+        class RaisingInt:
+            def __call__(self, data):
+                raise UnicodeEncodeError("utf-8", "x", 0, 1, "bad")
+
+        result = Deserializer._deserialize_primitive("value", RaisingInt())
+        assert result == "value"
+
+
+class TestDeserializeCollections:
+    def test_list_round_trip(self, deserializer):
+        source_list = ["Look", "another", "list"]
+        result = deserializer.deserialize(source_list, "list[str]")
+        assert isinstance(result, list)
+        assert result == source_list
+
+    def test_dict_round_trip(self, deserializer):
+        source_dict = {1: "one", 2: "two", 3: "three"}
+        result = deserializer.deserialize(source_dict, "dict(int, str)")
+        assert isinstance(result, dict)
+        assert result == source_dict
+
+    def test_dict_casts_values(self, deserializer):
+        source_dict = {"one": 1.0, "two": 2.0, "three": 3.1}
+        result = deserializer.deserialize(source_dict, "dict(str, int)")
+        assert isinstance(result, dict)
+        for key, val in source_dict.items():
+            assert key in result
+            assert result[key] == int(val)
+
+    @pytest.mark.parametrize(
+        ("type_name", "value"),
+        [
+            ("list[str]", ("foo")),
+            ("list[str]", "foo"),
+            ("list[str]", 1),
+            ("list[str]", 1.0),
+            ("list[str]", b"foo"),
+            ("list[str]", True),
+            ("list[str]", datetime.date.today()),
+            ("dict(str, int)", ["foo"]),
+            ("dict(str, int)", ("foo")),
+            ("dict(str, int)", 1),
+            ("dict(str, int)", 1.0),
+            ("dict(str, int)", b"foo"),
+            ("dict(str, int)", True),
+            ("dict(str, int)", datetime.date.today()),
+            ("str", ["foo"]),
+            ("str", ("foo",)),
+            ("str", datetime.date.today()),
+            ("int", [1]),
+            ("int", (1,)),
+            ("int", datetime.date.today()),
+            ("float", [1.0]),
+            ("float", (1.0,)),
+            ("float", datetime.date.today()),
+            ("bool", [True]),
+            ("bool", (True,)),
+            ("bool", datetime.date.today()),
+            ("bytes", [b"foo"]),
+            ("bytes", (b"foo",)),
+            ("bytes", datetime.date.today()),
+            ("datetime", ["2023-01-01T00:00:00Z"]),
+            ("datetime", ("2023-01-01T00:00:00Z",)),
+            ("datetime", datetime.datetime.now()),
+            ("datetime", 1),
+            ("datetime", 1.0),
+            ("datetime", True),
+            ("datetime", b"2023-01-01T00:00:00Z"),
+            ("date", ["2023-01-01"]),
+            ("date", ("2023-01-01",)),
+            ("date", datetime.date.today()),
+            ("date", 1),
+            ("date", 1.0),
+            ("date", True),
+            ("date", b"2023-01-01"),
+        ],
+    )
+    def test_wrong_type_raises_type_error(self, deserializer, type_name, value):
+        with pytest.raises(TypeError) as error:
+            deserializer.deserialize(value, type_name)
+        assert type_name in str(error.value)
+        assert str(type(value)) in str(error.value)
+
+
+class TestDeserializeDates:
+    def test_date_round_trip(self, deserializer):
+        source_date = datetime.date(2371, 4, 26)
+        result = deserializer.deserialize(source_date.isoformat(), "date")
+        assert isinstance(result, datetime.date)
+        assert result == source_date
+
+    def test_datetime_round_trip(self, deserializer):
+        source_datetime = datetime.datetime(2371, 4, 26, 4, 39, 21)
+        result = deserializer.deserialize(source_datetime.isoformat(), "datetime")
+        assert isinstance(result, datetime.datetime)
+        assert result == source_datetime
+
+    @pytest.mark.parametrize("object_type", ("date", "datetime"))
+    def test_invalid_date_like_raises_api_exception(self, deserializer, object_type):
+        invalid_date = "NOT-A-DATE"
+        with pytest.raises(ApiException) as exception_info:
+            deserializer.deserialize(invalid_date, object_type)
+        assert invalid_date in exception_info.value.reason_phrase
+        assert f"{object_type} object" in exception_info.value.reason_phrase
+
+
+class TestDeserializeModels:
+    def test_model_round_trip(self, deserializer):
+        from . import models
+
+        model_instance = models.ExampleModel("foo", 3, False, ["It's", "a", "list"])
+        model_dict = {
+            "Boolean": False,
+            "Integer": 3,
+            "ListOfStrings": ["It's", "a", "list"],
+            "String": "foo",
+        }
+        result = deserializer.deserialize(model_dict, "ExampleModel")
+        assert isinstance(result, models.ExampleModel)
+        assert result == model_instance
+
+    def test_model_from_string_creates_empty_instance(self, deserializer):
+        from . import models
+
+        result = deserializer.deserialize("unused", "ExampleModel")
+        assert isinstance(result, models.ExampleModel)
+
+    @pytest.mark.parametrize(
+        "value", [[("Boolean", False)], (("Boolean", False),), 1, 1.0, True, b"foo"]
+    )
+    def test_model_with_incorrect_value_type_raises_type_error(self, deserializer, value):
+        with pytest.raises(TypeError) as exception_info:
+            deserializer.deserialize(value, "ExampleModel")
+        assert "dict or string" in str(exception_info.value)
+
+    def test_model_with_discriminator(self, deserializer):
+        from . import models
+
+        model_instance = models.ExampleModel("foo", 3, False, ["It's", "a", "list"])
+        model_dict = {
+            "Boolean": False,
+            "Integer": 3,
+            "ListOfStrings": ["It's", "a", "list"],
+            "String": "foo",
+            "modelType": "ExampleModel",
+        }
+        result = deserializer.deserialize(model_dict, "ExampleBaseModel")
+        assert isinstance(result, models.ExampleModel)
+        assert result == model_instance
+
+    def test_empty_model_returns_raw_string_data(self, deserializer):
+        result = deserializer.deserialize("Good", "EmptyModelReturningRawData")
+        assert result == "Good"
+
+    def test_empty_model_continues_after_probe_error(self, deserializer):
+        result = deserializer.deserialize("payload", "EmptyModelWithProbeError")
+        assert isinstance(result, EmptyModelWithProbeError)
+
+    def test_dict_backed_model_preserves_extra_keys(self, deserializer):
+        result = deserializer.deserialize(
+            {"Label": "primary", "Extra": 99},
+            "DictBackedModel",
+        )
+        assert isinstance(result, DictBackedModel)
+        assert result.label == "primary"
+        assert result["Extra"] == 99
+
+    def test_model_without_discriminator_skips_not_implemented(self, deserializer):
+        result = deserializer.deserialize({"Name": "widget"}, "ModelWithoutDiscriminator")
+        assert isinstance(result, ModelWithoutDiscriminator)
+        assert result.name == "widget"
+
+
+class TestDeserializeEnums:
+    def test_enum_model_returns_constant_value(self, deserializer):
+        from . import models
+
+        result = deserializer.deserialize("Good", "ExampleModelWithEnum")
+        assert result == models.ExampleModelWithEnum().GOOD
+
+    def test_string_enum(self, deserializer):
+        from . import models
+
+        result = deserializer.deserialize("Good", "ExampleEnum")
+        assert isinstance(result, models.ExampleEnum)
+        assert result == models.ExampleEnum.GOOD
+
+    def test_int_enum(self, deserializer):
+        from . import models
+
+        result = deserializer.deserialize(200, "ExampleIntEnum")
+        assert isinstance(result, models.ExampleIntEnum)
+        assert result == models.ExampleIntEnum._200
+
+    @pytest.mark.parametrize(
+        ["value", "target_enum", "expected_error_msg"],
+        [
+            ("200", "ExampleIntEnum", "'200' is not a valid ExampleIntEnum"),
+            (4.5, "ExampleIntEnum", "4.5 is not a valid ExampleIntEnum"),
+            (4, "ExampleIntEnum", "4 is not a valid ExampleIntEnum"),
+            ("SomeValue", "ExampleEnum", "'SomeValue' is not a valid ExampleEnum"),
+            (4.5, "ExampleEnum", "4.5 is not a valid ExampleEnum"),
+            (4, "ExampleEnum", "4 is not a valid ExampleEnum"),
+        ],
+    )
+    def test_invalid_enum_value_raises_helpful_message(
+        self, deserializer, value, target_enum, expected_error_msg
+    ):
+        with pytest.raises(ValueError, match=expected_error_msg):
+            deserializer.deserialize(value, target_enum)


### PR DESCRIPTION
## Summary
- Extract OpenAPI wire-format logic from `ApiClient` into `ModelRegistry`, `Deserializer`, and an internal `Serializer`.
- Preserve existing `ApiClient` APIs (`setup_client`, `sanitize_for_serialization`, `deserialize`, `call_api`) for generated clients.
- Export `ModelRegistry` and `Deserializer` for standalone deserialization without constructing a full HTTP client.

## Design notes
- `ModelRegistry.register_module()` filters to `ModelBase` and `Enum` subclasses only (replacing the previous full `models.__dict__` assignment).
- `Serializer` remains internal; one instance per `ApiClient` for now.
- `ApiClient.deserialize` still handles HTTP payload extraction before delegating type resolution to `Deserializer`.

## Test plan
- [x] `uv run pytest` (364 passed, 10 skipped)
- [x] `uv run --frozen mypy ./src`
