### PR TITLE
Fix CaseInsensitiveOrderedDict pop behavior with missing key and no default value

### DIFF
--- a/doc/changelog.d/1119.fixed.md
+++ b/doc/changelog.d/1119.fixed.md
@@ -1,0 +1,1 @@
+Fix pop behavior

--- a/doc/changelog.d/1119.fixed.md
+++ b/doc/changelog.d/1119.fixed.md
@@ -1,1 +1,1 @@
-Fix pop behavior
+Fix CaseInsensitiveOrderedDict pop behavior with missing key and no default value

--- a/src/ansys/openapi/common/_util.py
+++ b/src/ansys/openapi/common/_util.py
@@ -37,6 +37,8 @@ import pyparsing as pp
 import requests
 from requests.structures import CaseInsensitiveDict
 
+_MISSING = object()
+
 
 class CaseInsensitiveOrderedDict(OrderedDict):
     """Preserves order of insertion and is case-insensitive.
@@ -76,9 +78,9 @@ class CaseInsensitiveOrderedDict(OrderedDict):
         """Override setdefault to use lower-case key."""
         return super().setdefault(k.lower(), default)
 
-    def pop(self, k: str, v: Any = object()) -> Any:  # noqa: B008
+    def pop(self, k: str, v: Any = _MISSING) -> Any:
         """Override pop to use lower-case key."""
-        if v is object():
+        if v is _MISSING:
             return super().pop(k.lower())
         return super().pop(k.lower(), v)
 

--- a/tests/test_utils_misc.py
+++ b/tests/test_utils_misc.py
@@ -68,8 +68,8 @@ class TestCaseInsensitiveOrderedDict:
         with pytest.raises(KeyError):
             _ = self.example_dict["BaZ"]
         assert self.example_dict.pop("grault", "ftagn") == "ftagn"
-        default_obj = self.example_dict.pop("spam")
-        assert isinstance(default_obj, object)
+        with pytest.raises(KeyError):
+            self.example_dict.pop("spam")
 
     def test_update(self):
         self.example_dict.update({"BaZ": "grault", "gRaUlT": "ftagn"})


### PR DESCRIPTION
Closes #1120 1120

Based on #1118 

Fix `CaseInsensitiveOrderedDict.pop` not raising `KeyError` on missing keys

Summary

Fixes a long-standing bug in `CaseInsensitiveOrderedDict.pop` where calling `pop(key)` on a missing key without a default silently returned a stale `object()` instance instead of raising `KeyError`.

Root cause

The original implementation used `object()` as the default argument sentinel and then tested identity against a second `object()` call:

```python
def pop(self, k: str, v: Any = object()) -> Any:
    if v is object():   # always False — new object every call
        return super().pop(k.lower())
    return super().pop(k.lower(), v)  # always reached, leaks sentinel on miss
```

Because `object()` creates a new unique instance on every call, `v is object()` is always `False`. The no-default branch was therefore unreachable, and a missing key would return the leaked sentinel rather than raise `KeyError`.

Fix

Replace the inline `object()` calls with a stable module-level sentinel so the identity check works correctly:

```python
_MISSING = object()

def pop(self, k: str, v: Any = _MISSING) -> Any:
    if v is _MISSING:
        return super().pop(k.lower())   # raises KeyError if missing — correct
    return super().pop(k.lower(), v)
```

Test

Updated `test_pop` to assert that `pop` on a missing key with no default raises `KeyError`, matching standard `dict.pop` behaviour